### PR TITLE
fix promm resource spelling

### DIFF
--- a/terraform/aws/app-infrastructure/aws-prometheus-grafana/README.md
+++ b/terraform/aws/app-infrastructure/aws-prometheus-grafana/README.md
@@ -47,6 +47,6 @@ Below are the available Outputs contained within this DNS moudle:
 | amg-workspace-api-key |  | `module.grafana-workspace.amg-workspace-api-key` | AWS Grafana workspace api key |
 | amp_workspace_endpoint |  | `module.prometheus-workspace.amp_workspace_endpoint` | AWS Prometheus workspace endpoint |
 | amp_workspace_id |  | `module.prometheus-workspace.amp_workspace_id` | AWS Prometheus workspace ID |
-| prommetheus_role_arn |  | `module.iam-role.prommetheus_role_arn` | AWS Prometheus Role ARN |
+| prometheus_role_arn |  | `module.iam-role.prometheus_role_arn` | AWS Prometheus Role ARN |
 | sns_topic_arn |  | `module.prometheus-workspace.sns_topic_arn` | The ARN of the SNS topic |
 

--- a/terraform/aws/app-infrastructure/aws-prometheus-grafana/main.tf
+++ b/terraform/aws/app-infrastructure/aws-prometheus-grafana/main.tf
@@ -44,7 +44,7 @@ module "prometheus-helm" {
   repository                    = var.repository
   chart                         = var.chart
   workspace_id                  = module.prometheus-workspace.amp_workspace_id
-  iam_proxy_prometheus_role_arn = module.iam-role.prommetheus_role_arn
+  iam_proxy_prometheus_role_arn = module.iam-role.prometheus_role_arn
   values_file_path              = var.values_file_path
   dependency_update             = var.dependency_update
   lint                          = var.lint

--- a/terraform/aws/app-infrastructure/aws-prometheus-grafana/modules/iam-roles/main.tf
+++ b/terraform/aws/app-infrastructure/aws-prometheus-grafana/modules/iam-roles/main.tf
@@ -24,7 +24,7 @@ resource "aws_iam_policy" "policy" {
   })
 }
 
-resource "aws_iam_role" "prommetheus_role" {
+resource "aws_iam_role" "prometheus_role" {
   name = "prometheus_role"
 
   assume_role_policy = <<EOF
@@ -55,7 +55,7 @@ EOF
 
 resource "aws_iam_policy_attachment" "prometheus-attach" {
   name       = "prometheus-policy-attachment"
-  roles      = [aws_iam_role.prommetheus_role.name]
+  roles      = [aws_iam_role.prometheus_role.name]
   policy_arn = aws_iam_policy.policy.arn
 }
 

--- a/terraform/aws/app-infrastructure/aws-prometheus-grafana/modules/iam-roles/outputs.tf
+++ b/terraform/aws/app-infrastructure/aws-prometheus-grafana/modules/iam-roles/outputs.tf
@@ -1,6 +1,6 @@
 
-output "prommetheus_role_arn" {
-  value = aws_iam_role.prommetheus_role.arn
+output "prometheus_role_arn" {
+  value = aws_iam_role.prometheus_role.arn
 }
 
 

--- a/terraform/aws/app-infrastructure/aws-prometheus-grafana/modules/prometheus-workspace/main.tf
+++ b/terraform/aws/app-infrastructure/aws-prometheus-grafana/modules/prometheus-workspace/main.tf
@@ -87,7 +87,7 @@ resource "aws_iam_policy" "sns-policy" {
 
 
 
-resource "aws_iam_role" "amp_prommetheus_role" {
+resource "aws_iam_role" "amp_prometheus_role" {
   name = "amp_prometheus_role"
 
   assume_role_policy = <<EOF
@@ -114,7 +114,7 @@ EOF
 
 resource "aws_iam_policy_attachment" "sns-attach" {
   name       = "sns-policy-attachment"
-  roles      = [aws_iam_role.amp_prommetheus_role.name]
+  roles      = [aws_iam_role.amp_prometheus_role.name]
   policy_arn = aws_iam_policy.sns-policy.arn
 }
 

--- a/terraform/aws/app-infrastructure/aws-prometheus-grafana/outputs.tf
+++ b/terraform/aws/app-infrastructure/aws-prometheus-grafana/outputs.tf
@@ -6,8 +6,8 @@ output "amp_workspace_endpoint" {
   value = module.prometheus-workspace.amp_workspace_endpoint
 }
 
-output "prommetheus_role_arn" {
-  value = module.iam-role.prommetheus_role_arn
+output "prometheus_role_arn" {
+  value = module.iam-role.prometheus_role_arn
 }
 
 output "sns_topic_arn" {


### PR DESCRIPTION
Resource spelling fixed. On apply for some reason it does requires the IAM roles for Prometheus are 'manually' deleted first.