### PR TITLE
added boolean variable to control creation of synthetics-canary

### DIFF
--- a/terraform/aws/development-infrastructure/synthetics-canary/README.md
+++ b/terraform/aws/development-infrastructure/synthetics-canary/README.md
@@ -25,3 +25,7 @@ Make URLs a list instead of a single value
 Consider using email address list outside of cloudwatch synthetics for
 other SNS topics
 
+
+# apply manually outside of pipeline
+terraform plan -var-file=inputs.tfvars -var 'synthetics_canary_create=true'
+terraform apply -var-file=inputs.tfvars -var 'synthetics_canary_create=true'

--- a/terraform/aws/development-infrastructure/synthetics-canary/README.md
+++ b/terraform/aws/development-infrastructure/synthetics-canary/README.md
@@ -27,5 +27,5 @@ other SNS topics
 
 
 # apply manually outside of pipeline
-terraform plan -var-file=inputs.tfvars -var 'synthetics_canary_create=true'
-terraform apply -var-file=inputs.tfvars -var 'synthetics_canary_create=true'
+terraform plan -var-file=inputs.tfvars -var='synthetics_canary_create=true'
+terraform apply -var-file=inputs.tfvars -var='synthetics_canary_create=true'

--- a/terraform/aws/development-infrastructure/synthetics-canary/synthetics-canary.tf
+++ b/terraform/aws/development-infrastructure/synthetics-canary/synthetics-canary.tf
@@ -1,20 +1,5 @@
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/synthetics_canary
 
-# variable "synthetics_canary_email_addresses" {
-#   description = "List of email addresses to send notifications"
-#   type        = list(string)
-# }
-
-variable "synthetics_canary_url" {
-  description = "url to monitor"
-  type        = string
-}
-
-variable "synthetics_canary_bucket_name" {
-  description = "bucket name for synthetics output"
-  type        = string
-}
-
 # attempt to rebuild canary zip file if lambda code changes
 locals {
   module_name = "synthetics-canary"

--- a/terraform/aws/development-infrastructure/synthetics-canary/synthetics-canary.tf
+++ b/terraform/aws/development-infrastructure/synthetics-canary/synthetics-canary.tf
@@ -40,6 +40,7 @@ data "archive_file" "lambda_canary_zip" {
 }
 
 resource "aws_s3_bucket" "canary-output-bucket" {
+  count = var.synthetics_canary_create ? 1 : 0
   bucket  = var.synthetics_canary_bucket_name
   force_destroy = true
   lifecycle {
@@ -118,6 +119,7 @@ data "aws_iam_policy_document" "canary-policy" {
 }
 
 resource "aws_iam_role" "canary-role" {
+  count = var.synthetics_canary_create ? 1 : 0
   name               = "canary-role"
   assume_role_policy = data.aws_iam_policy_document.canary-assume-role-policy.json
   description        = "IAM role for AWS Synthetic Monitoring Canaries"
@@ -128,6 +130,7 @@ resource "aws_iam_role" "canary-role" {
 }
 
 resource "aws_iam_policy" "canary-policy" {
+  count = var.synthetics_canary_create ? 1 : 0
   name        = "canary-policy"
   policy      = data.aws_iam_policy_document.canary-policy.json
   description = "IAM role for AWS Synthetic Monitoring Canaries"
@@ -138,6 +141,7 @@ resource "aws_iam_policy" "canary-policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "canary-policy-attachment" {
+  count = var.synthetics_canary_create ? 1 : 0
   role       = aws_iam_role.canary-role.name
   policy_arn = aws_iam_policy.canary-policy.arn
 }
@@ -147,6 +151,7 @@ resource "aws_iam_role_policy_attachment" "canary-policy-attachment" {
 # }
 
 resource "aws_sns_topic" "topic" {
+  count = var.synthetics_canary_create ? 1 : 0
   name = "url_monitoring_topic"
   tags = {
     ModuleVersion = "${local.module_name}-${local.module_serial_number}" 
@@ -161,6 +166,7 @@ resource "aws_sns_topic" "topic" {
 # }
 
 resource "aws_synthetics_canary" "synthetics_canary_url_monitoring" {
+  count = var.synthetics_canary_create ? 1 : 0
   name                       = "canary_monitoring"
   artifact_s3_location = "s3://${aws_s3_bucket.canary-output-bucket.bucket}/"
   execution_role_arn         = aws_iam_role.canary-role.arn
@@ -177,6 +183,7 @@ resource "aws_synthetics_canary" "synthetics_canary_url_monitoring" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "canary_alarm" {
+  count = var.synthetics_canary_create ? 1 : 0
   alarm_name          = "synthetics_canary_url_monitoring_alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"

--- a/terraform/aws/development-infrastructure/synthetics-canary/variables.tf
+++ b/terraform/aws/development-infrastructure/synthetics-canary/variables.tf
@@ -1,0 +1,20 @@
+
+variable "synthetics_canary_bucket_name" {
+  description = "bucket name for synthetics output"
+  type        = string
+}
+variable "synthetics_canary_url" {
+  description = "A URL to use for monitoring alerts"
+  type        = string
+}
+# this is defined outside the pipeline (at cli?)
+variable "synthetics_canary_create" {
+  type        = bool
+  description = "Create canary required resources?"
+  default     = false
+}
+#variable "synthetics_canary_email_addresses" {
+#  description = "A list of email addresses to use for monitoring alerts"
+#  type        = list(string)
+#}
+


### PR DESCRIPTION
added to account template in DevOpsTools, to use in specific accounts the updated variables.tf file and synthetics-canary.tf file can be copied into account specific file.  The variable needs to be set outside the pipeline controlled inputs.tfvars file (command line flag or additional -var-file)