### PR TITLE
disable lifecycle by default

### DIFF
--- a/terraform/aws/app-infrastructure/s3-bucket/variables.tf
+++ b/terraform/aws/app-infrastructure/s3-bucket/variables.tf
@@ -6,7 +6,7 @@ variable "bucket_prefix" {
 variable "enable_default_bucket_lifecycle_policy" {
   type = string
   description = "Whether the default rule is currently being applied. Valid values: Enabled or Disabled."
-  default = "Enabled"
+  default = "Disabled"
   validation {
     condition  = var.enable_default_bucket_lifecycle_policy == "Enabled" || var.enable_default_bucket_lifecycle_policy == "Disabled"
     error_message = "enable_default_bucket_lifecycle_policy for the s3-bucket module must either \"Enabled\" or \"Disabled\""


### PR DESCRIPTION
disable by default to meet retention requirements, need to add enable and configuration to documentation.  Development environments could be enabled variables in account-template
