### PR TITLE
pinned to 1.5.0

### DIFF
--- a/terraform/aws/app-infrastructure/efs/main.tf
+++ b/terraform/aws/app-infrastructure/efs/main.tf
@@ -3,19 +3,20 @@ locals {
 }
 
 module "efs" {
-  source = "terraform-aws-modules/efs/aws"
+  source  = "terraform-aws-modules/efs/aws"
+  version = "1.5.0"
 
-  name           = local.efs_name
-  encrypted      = true
-  kms_key_arn    = var.kms_key_arn
+  name        = local.efs_name
+  encrypted   = true
+  kms_key_arn = var.kms_key_arn
 
   # File system policy
   attach_policy                      = true
   bypass_policy_lockout_safety_check = false
   policy_statements = [
     {
-      sid     = "AllowViaMountTarget"
-      effect  = "Allow"
+      sid    = "AllowViaMountTarget"
+      effect = "Allow"
       actions = [
         "elasticfilesystem:ClientRootAccess",
         "elasticfilesystem:ClientWrite",

--- a/terraform/aws/app-infrastructure/eks-nbs/irsa.tf
+++ b/terraform/aws/app-infrastructure/eks-nbs/irsa.tf
@@ -1,13 +1,14 @@
 module "efs_cni_irsa_role" {
-  source    = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.34.0"
 
-  role_name = "${local.eks_name}-efs-cni" #defined in main.tf
-  create_role = true
+  role_name             = "${local.eks_name}-efs-cni" #defined in main.tf
+  create_role           = true
   attach_efs_csi_policy = true
 
   oidc_providers = {
     main = {
-      provider_arn               = module.eks.oidc_provider_arn
+      provider_arn = module.eks.oidc_provider_arn
       namespace_service_accounts = [
         "kube-system:aws-node",
         "kube-system:efs-csi-controller-sa"
@@ -17,10 +18,11 @@ module "efs_cni_irsa_role" {
 }
 
 module "cert_manager_cni_irsa_role" {
-  source    = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.34.0"
 
-  role_name = "${local.eks_name}-cert-manager-cni" #defined in main.tf
-  create_role = true
+  role_name                  = "${local.eks_name}-cert-manager-cni" #defined in main.tf
+  create_role                = true
   attach_cert_manager_policy = true
 
   oidc_providers = {


### PR DESCRIPTION
efs module to fix 
Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider hashicorp/aws: no available releases match the given constraints >= 2.49.0, >= 3.29.0, >= 3.72.0, >= 4.0.0, >= 4.20.0, >= 4.40.0, >= 4.47.0, >= 4.57.0, >= 4.59.0, >= 4.65.0, >=
│ 5.20.0, 5.24.0, 5.31.0, >= 5.32.0