### PR TITLE
github_release_tag for nbs-classic-ecs

### DIFF
--- a/terraform/aws/development-infrastructure/nbs-legacy/nbs-classic-ecs.tf
+++ b/terraform/aws/development-infrastructure/nbs-legacy/nbs-classic-ecs.tf
@@ -84,6 +84,10 @@ resource "aws_ecs_task_definition" "task" {
         {
           name  = "DATABASE_ENDPOINT",
           value = "${var.nbs_db_dns}"
+        },
+        {
+          name  = "GITHUB_RELEASE_TAG",
+          value = "${var.nbs_github_release_tag}"
         }
       ]
         logConfiguration = {

--- a/terraform/aws/development-infrastructure/nbs-legacy/variables.tf
+++ b/terraform/aws/development-infrastructure/nbs-legacy/variables.tf
@@ -173,6 +173,11 @@ variable "nbs_db_dns" {
 
 }
 
+variable "nbs_github_release_tag" {
+  description = "Create URL and download Release Package. Default is always latest or Null"
+  type        = string
+}
+
 variable "kms_arn_shared_services_bucket" {
   description = "KMS key arn used to encrypt shared services s3 bucket"
   type        = string


### PR DESCRIPTION
This is to automate the nbs user training guide configuration within the ecs before the container comes up. It downloads the latest release package from nedss-modernization releases.