### PR TITLE
fix wildfly server service and add default latest 2019 windows ami

### DIFF
--- a/terraform/aws/development-infrastructure/nbs-legacy/variables.tf
+++ b/terraform/aws/development-infrastructure/nbs-legacy/variables.tf
@@ -83,9 +83,9 @@ variable "ecs_memory" {
 }
 
 variable "ami" {
-  description = "AMI for EC2 instance. Required if deploy_on_ecs == false."
+  description = "AMI for EC2 instance. (Defaul) Null will use latest Windows 2022 Core Base ami. Required if deploy_on_ecs == false."
   type        = string
-  default = ""
+  default = null
 }
 
 # variable "legacy_vpc_id" {


### PR DESCRIPTION
Wildfly service fix:
- Added environment variables to be available during the script as well

AMI:
- Updated EC2 module to latest version
- Added ability to use latest Windows 2019 AMI and a specific ami
- - To use the latest Windows 2019 ami simply set var.ami to null (default module behavior

NOTE: Windows server 2022 has more problems to debug for wildfly service, so I suggest we wait on that upgrade