### PR TITLE
Sgz parameterize db

### DIFF
--- a/terraform/aws/development-infrastructure/nbs-legacy/main.tf
+++ b/terraform/aws/development-infrastructure/nbs-legacy/main.tf
@@ -3,9 +3,11 @@
 
 # NBS application server
 module "app_server" {
+  count = var.deploy_on_ecs ? 0 : 1
   source  = "terraform-aws-modules/ec2-instance/aws"
   version = "~> 5.7"
-  count = var.deploy_on_ecs ? 0 : 1
+  depends_on = [ aws_ssm_parameter.odse_user, aws_ssm_parameter.odse_pass, aws_ssm_parameter.rdb_user, aws_ssm_parameter.rdb_pass, aws_ssm_parameter.srte_user, aws_ssm_parameter.srte_pass]
+  
 
   user_data_replace_on_change = true
 
@@ -22,6 +24,7 @@ module "app_server" {
   iam_role_policies = {
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
     AmazonS3FullAccess           = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+    AmazonSSMReadOnlyAccess      =  "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
   }
 
   tags = var.tags
@@ -46,13 +49,7 @@ module "app_server" {
   user_data = <<-EOT
 <powershell>
 Write-Verbose "NOTICE: turn off UAC"
-
-#Initialize hastable for data sources
-$connectionURLs = @{ "NedssDS" = "jdbc:sqlserver://${var.nbs_db_dns}:1433;SelectMethod=direct;DatabaseName=nbs_odse";
-                        "MsgOutDS" = "jdbc:sqlserver://${var.nbs_db_dns}:1433;SelectMethod=direct;DatabaseName=nbs_msgoute";
-                        "ElrXrefDS" = "jdbc:sqlserver://${var.nbs_db_dns}:1433;SelectMethod=direct;DatabaseName=nbs_msgoute";
-                        "RdbDS" = "jdbc:sqlserver://${var.nbs_db_dns}:1433;SelectMethod=direct;DatabaseName=rdb";
-                        "SrtDS" = "jdbc:sqlserver://${var.nbs_db_dns}:1433;SelectMethod=direct;DatabaseName=nbs_srte"}
+reg.exe ADD "HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System" /v EnableLUA /t REG_DWORD /d 0 /f 
             
 #Format windows D drive
 Initialize-Disk  -Number 1 -PartitionStyle "MBR"
@@ -66,16 +63,60 @@ Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 Copy-S3Object -BucketName "${var.artifacts_bucket_name}" -Key "nbs/${var.deployment_package_key}" -LocalFile D:\${var.deployment_package_key}
 Expand-Archive -Path D:\${var.deployment_package_key} -DestinationPath D:\
 
+# install AWS CLI and refresh Path
+Start-Process msiexec.exe -Wait -ArgumentList '/i https://awscli.amazonaws.com/AWSCLIV2.msi /qn /norestart'
+$env:Path = [System.Environment]::GetEnvironmentVariable('Path','Machine') + ";" + [System.Environment]::GetEnvironmentVariable('Path','User')
+
+# install sqlcmd
+mkdir C:\executables\sqlcmd
+Invoke-WebRequest -Uri https://github.com/microsoft/go-sqlcmd/releases/download/v1.8.2/sqlcmd-windows-amd64.zip -OutFile C:\executables\sqlcmd\sqlcmd-windows-amd64.zip
+Expand-Archive C:\executables\sqlcmd\sqlcmd-windows-amd64.zip C:\executables\sqlcmd\
+[Environment]::SetEnvironmentVariable("Path", "$env:Path;C:\executables\sqlcmd", "Machine")
+
+# Set WildFly Memory and JAVA_TOOL_OPTIONS
+$env:JAVA_OPTS="-Xms$env:${var.java_memory} -Xmx$env:${var.java_memory} -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Xss4m"
+$env:JAVA_OPTS="$env:JAVA_OPTS -Djava.net.preferIPv4Stack=true"
+$env:JAVA_OPTS="$env:JAVA_OPTS -Djboss.modules.system.pkgs=org.jboss.byteman"
+$env:JAVA_TOOL_OPTIONS="-Dsun.stdout.encoding=cp437 -Dsun.stderr.encoding=cp437"
+
+# Obtain parameters from parameter store
+$odse_user = $(aws ssm get-parameter --name ${aws_ssm_parameter.odse_user.name} --with-decryption | ConvertFrom-Json).parameter.value
+$odse_pass = $(aws ssm get-parameter --name ${aws_ssm_parameter.odse_pass.name} --with-decryption | ConvertFrom-Json).parameter.value
+$rdb_user = $(aws ssm get-parameter --name ${aws_ssm_parameter.rdb_user.name} --with-decryption | ConvertFrom-Json).parameter.value
+$rdb_pass = $(aws ssm get-parameter --name ${aws_ssm_parameter.rdb_pass.name} --with-decryption | ConvertFrom-Json).parameter.value
+$srte_user = $(aws ssm get-parameter --name ${aws_ssm_parameter.srte_user.name} --with-decryption | ConvertFrom-Json).parameter.value
+$srte_pass = $(aws ssm get-parameter --name ${aws_ssm_parameter.srte_pass.name} --with-decryption | ConvertFrom-Json).parameter.value
+
+#Initialize hastable for data sources
+$connectionURLs = @{ "NedssDS" = "jdbc:sqlserver://${var.nbs_db_dns}:1433;SelectMethod=direct;DatabaseName=nbs_odse";                     
+                     "MsgOutDS" = "jdbc:sqlserver://${var.nbs_db_dns}:1433;SelectMethod=direct;DatabaseName=nbs_msgoute";                     
+                     "ElrXrefDS" = "jdbc:sqlserver://${var.nbs_db_dns}:1433;SelectMethod=direct;DatabaseName=nbs_msgoute";                     
+                     "RdbDS" = "jdbc:sqlserver://${var.nbs_db_dns}:1433;SelectMethod=direct;DatabaseName=rdb";                    
+                     "SrtDS" = "jdbc:sqlserver://${var.nbs_db_dns}:1433;SelectMethod=direct;DatabaseName=nbs_srte"}
+
+$connectionURLs_user = @{ "NedssDS" = "$odse_user";                     
+                          "MsgOutDS" = "$odse_user";                    
+                          "ElrXrefDS" = "$odse_user";                     
+                          "RdbDS" = "$rdb_user";                     
+                          "SrtDS" = "$srte_user"}
+
+$connectionURLs_pass = @{ "NedssDS" = "$odse_pass";                     
+                          "MsgOutDS" = "$odse_pass";                     
+                          "ElrXrefDS" = "$odse_pass";                     
+                          "RdbDS" = "$rdb_pass";                     
+                          "SrtDS" = "$srte_pass"}
+
 # Set environment variables thatdon't go away if server reboots or stopped and restarted
 [Environment]::SetEnvironmentVariable("JAVA_HOME", "D:\wildfly-10.0.0.Final\Java\jdk8u412b08", "Machine")
 [Environment]::SetEnvironmentVariable("JBOSS_HOME", "D:\wildfly-10.0.0.Final", "Machine")
-[Environment]::SetEnvironmentVariable("Path", $env:Path + ";D:\wildfly-10.0.0.Final\Java\jdk8u412b08\bin", "Machine")
+[Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\executables\sqlcmd;D:\wildfly-10.0.0.Final\Java\jdk8u412b08\bin", "Machine")
+[Environment]::SetEnvironmentVariable("JAVA_OPTS", $env:JAVA_OPTS, "Machine")
+[Environment]::SetEnvironmentVariable("JAVA_TOOL_OPTIONS", $env:JAVA_TOOL_OPTIONS, "Machine")
 
 # Set local variables for use in script
 $env:JAVA_HOME="D:\wildfly-10.0.0.Final\Java\jdk8u412b08"
 $env:JBOSS_HOME="D:\wildfly-10.0.0.Final"
 $env:Path=$env:Path + ";D:\wildfly-10.0.0.Final\Java\jdk8u412b08\bin"
-
 
 #Replace datasources in standalone.xml file
 $xmlFileName = "D:\wildfly-10.0.0.Final\nedssdomain\configuration\standalone.xml"
@@ -86,21 +127,36 @@ $xmlFileName = "D:\wildfly-10.0.0.Final\nedssdomain\configuration\standalone.xml
 #Read the existing XML file
 [xml]$xmlDoc = Get-Content $xmlFileName
 
-#Search and replace db host name in connection URL
-$subsystems = $xmlDoc. server.profile.subsystem
-$subsystems | % { 
-    if ($_.xmlns -eq "urn:jboss:domain:datasources:4.0") {
+#Search and replace db host name, user, pass in connection URL
+$subsystems = $xmlDoc.server.profile.subsystem
+$subsystems | ForEach-Object { 
+  if ($_.xmlns -eq "urn:jboss:domain:datasources:4.0") {
     $datsources = $_.datasources.datasource
-     $datsources | % {
-         if ( $connectionURLs.ContainsKey($_.'pool-name')) {
-             $_.'connection-url' =  $connectionURLs[$_.'pool-name']
-        }
-    }
-    }
+    $datsources | ForEach-Object {
+      if ( $connectionURLs.ContainsKey($_.'pool-name')) {
+        $_.'connection-url' =  $connectionURLs[$_.'pool-name']
+        $_.security.'user-name' = $connectionURLs_user[$_.'pool-name']
+        $_.security.password = $connectionURLs_pass[$_.'pool-name']
+      }
+    }    
+  }
 }
 
 #Save XML file after connection url replacement
 $xmlDoc.Save($xmlFileName)
+
+# Update static BatchFiles
+# covid19ETL.bat
+
+$setenvFilePath = "$env:JBOSS_HOME\nedssdomain\Nedss\BatchFiles\covid19ETL.bat"
+$currentContent = Get-Content -Path $setenvFilePath
+
+$setEchoOff = "@echo off"
+$setDATABASE_ENDPOINT = "set DATABASE_ENDPOINT=${var.nbs_db_dns}"
+$setrdb_user = "set rdb_user=$rdb_user"
+$setrdb_pass = "set rdb_pass=$rdb_pass"
+$newContent = $setEchoOff, $setDATABASE_ENDPOINT, $setrdb_user, $setrdb_pass, $currentContent
+$newContent | Set-Content -Path $setenvFilePath
 
 #Install wildfly windows service   
 Set-Location -Path "D:\wildfly-10.0.0.Final\bin\service"
@@ -194,7 +250,6 @@ foreach ($row in $csvDataUpdated) {
 Start-Service Wildfly
 Restart-Computer -Force
 </powershell>
-<powershellArguments>-ExecutionPolicy Unrestricted -NonInteractive</powershellArguments>
 EOT   
 }
 
@@ -233,3 +288,30 @@ resource "aws_iam_role_policy" "shared_s3_access" {
 
   depends_on = [module.app_server]
 }
+
+# # Add in-line IAM role for EC2 access to decrypt parameter store SecureString
+# resource "aws_iam_role_policy" "param_store_access" {
+#   count = var.deploy_on_ecs ? 0 : 1
+#   name = "${var.resource_prefix}-app-server-kms-policy"
+#   role = module.app_server[0].iam_role_name
+
+#   # Terraform's "jsonencode" function converts a
+#   # Terraform expression result to valid JSON syntax.
+#   policy = jsonencode({
+#     Version = "2012-10-17"
+#     Statement = [      
+#       {
+#         Action = [
+#           "kms:Decrypt",
+#           "kms:DescribeKey",
+#           "kms:GenerateDataKey"
+#         ]
+#         Effect   = "Allow"
+#         Resource = try(var.param_store_key_id, "*")
+#       },
+#     ]
+#   })
+
+#   depends_on = [module.app_server]
+# }
+

--- a/terraform/aws/development-infrastructure/nbs-legacy/main.tf
+++ b/terraform/aws/development-infrastructure/nbs-legacy/main.tf
@@ -288,30 +288,3 @@ resource "aws_iam_role_policy" "shared_s3_access" {
 
   depends_on = [module.app_server]
 }
-
-# # Add in-line IAM role for EC2 access to decrypt parameter store SecureString
-# resource "aws_iam_role_policy" "param_store_access" {
-#   count = var.deploy_on_ecs ? 0 : 1
-#   name = "${var.resource_prefix}-app-server-kms-policy"
-#   role = module.app_server[0].iam_role_name
-
-#   # Terraform's "jsonencode" function converts a
-#   # Terraform expression result to valid JSON syntax.
-#   policy = jsonencode({
-#     Version = "2012-10-17"
-#     Statement = [      
-#       {
-#         Action = [
-#           "kms:Decrypt",
-#           "kms:DescribeKey",
-#           "kms:GenerateDataKey"
-#         ]
-#         Effect   = "Allow"
-#         Resource = try(var.param_store_key_id, "*")
-#       },
-#     ]
-#   })
-
-#   depends_on = [module.app_server]
-# }
-

--- a/terraform/aws/development-infrastructure/nbs-legacy/parameter_store.tf
+++ b/terraform/aws/development-infrastructure/nbs-legacy/parameter_store.tf
@@ -1,0 +1,48 @@
+resource "aws_ssm_parameter" "odse_user" {
+    description = "Database user for odse"
+    name  = "/${var.resource_prefix}-app-server/odse_user"
+    type  = "SecureString"
+    value = "${var.odse_user}"
+    key_id = var.param_store_key_id 
+}
+
+resource "aws_ssm_parameter" "odse_pass" {
+    description = "Database password for odse"
+    name  = "/${var.resource_prefix}-app-server/odse_pass"
+    type  = "SecureString"
+    value = "${var.odse_pass}"
+    key_id = var.param_store_key_id
+}
+
+resource "aws_ssm_parameter" "rdb_user" {
+    description = "Database user for rdb"
+    name  = "/${var.resource_prefix}-app-server/rdb_user"
+    type  = "SecureString"
+    value = "${var.rdb_user}"
+    key_id = var.param_store_key_id 
+}
+
+resource "aws_ssm_parameter" "rdb_pass" {
+    description = "Database password for rdb"
+    name  = "/${var.resource_prefix}-app-server/rdb_pass"
+    type  = "SecureString"
+    value = "${var.rdb_pass}"
+    key_id = var.param_store_key_id 
+}
+
+resource "aws_ssm_parameter" "srte_user" {
+    description = "Database user for srte"
+    name  = "/${var.resource_prefix}-app-server/srte_user"
+    type  = "SecureString"
+    value = "${var.srte_user}"
+    key_id = var.param_store_key_id 
+}
+
+resource "aws_ssm_parameter" "srte_pass" {
+    description = "Database password for srte"
+    name  = "/${var.resource_prefix}-app-server/srte_pass"
+    type  = "SecureString"
+    value = "${var.srte_pass}"
+    key_id = var.param_store_key_id 
+}
+

--- a/terraform/aws/development-infrastructure/nbs-legacy/variables.tf
+++ b/terraform/aws/development-infrastructure/nbs-legacy/variables.tf
@@ -214,6 +214,49 @@ variable "internal" {
   default     = null
 }
 
+variable "param_store_key_id" {
+  description = "(optional) KMS key id used to encrypt parameter store SecureString to be read by EC2 instance"
+  type        = string
+  default = null
+}
+
+# Database credentials to be encrypted and stored as SecureStrings in parameter store
+variable "odse_user" {
+  description = "User for odse database"
+  type        = string
+  sensitive = true
+}
+
+variable "odse_pass" {
+  description = "Password for odse database"
+  type        = string
+  sensitive = true
+}
+
+variable "rdb_user" {
+  description = "User for odse database"
+  type        = string
+  sensitive = true
+}
+
+variable "rdb_pass" {
+  description = "Password for odse database"
+  type        = string
+  sensitive = true
+}
+
+variable "srte_user" {
+  description = "User for odse database"
+  type        = string
+  sensitive = true
+}
+
+variable "srte_pass" {
+  description = "Password for odse database"
+  type        = string
+  sensitive = true
+}
+
 
 # Variable which creates a Windows Scheduled Task for BatchFiles
 # Batch include .bat scripts located in the nbs6 subdirectory "BatchFiles" or anything within that subdirectory
@@ -229,4 +272,10 @@ variable "windows_scheduled_tasks" {
   description = "Scheduled tasks in semicolon-separated list providing, note the trailing ';' - filename,scriptPathFromWorkDir,startTime,frequencyDays,frequencyHours,frequencyMinutes;"
   type = string
   default = "ELRImporter.bat,, 6am, 0, 0, 2; MsgOutProcessor.bat,, 8pm, 0, 0 , 2; UserProfileUpdateProcess.bat, retired\\, 12am, 1, 0, 0; DeDuplicationSimilarBatchProcess.bat, retired\\, 7pm, 1, 0 , 0; covid19ETL.bat,, 5am, 1, 0 , 0;"
+}
+
+variable "java_memory" {
+  description = "Memory for Wildfly server to run Java (NOTE should not exceed 70% of VM memory)"
+  type = string
+  default = "4g"
 }


### PR DESCRIPTION
Modified file in nbs 6.0.16.2 covid19ETL.bat to use parameters rdb_user and rdb_pass and stored in s3. This is an optional ETL file that runs using SQLCMD. 

This updates modifies standalone.xml on the fly so no file updates were needed there. Usernames and password get updated on EC2 launch when running the userdata script to pull values from SecureString stored parameter store resources.