### PR TITLE
update default cluster version to 1.32

### DIFF
--- a/terraform/aws/app-infrastructure/eks-nbs/variables.tf
+++ b/terraform/aws/app-infrastructure/eks-nbs/variables.tf
@@ -38,7 +38,7 @@ variable "sso_role_arn" {
 
 variable "cluster_version" {
   description = "Version of the AWS EKS cluster to provision"
-  default = "1.29"
+  default = "1.32"
 }
 
 variable "desired_nodes_count" {


### PR DESCRIPTION
If more than 1 version behind you will need to either update the version 1 at a time through TF using custer_version variable OR update both the eks cluster and managed nodes version manually in console.