### PR TITLE
fix(eks_nbs): add try to optional irsa resources

### DIFF
--- a/terraform/aws/modules/2-nbs7/eks-nbs/irsa.tf
+++ b/terraform/aws/modules/2-nbs7/eks-nbs/irsa.tf
@@ -50,7 +50,7 @@ module "otel_collector_irsa_role" {
   }
 
   policies = {
-    policy = aws_iam_policy.otel_collector_irsa_policy[0].arn
+    policy = try(aws_iam_policy.otel_collector_irsa_policy[0].arn, null)
   }
 }
 
@@ -96,7 +96,7 @@ module "datacompare_irsa_role" {
   }
 
   policies = {
-    policy = aws_iam_policy.datacompare_irsa_policy[0].arn
+    policy = try(aws_iam_policy.datacompare_irsa_policy[0].arn, null)
   }
 }
 

--- a/terraform/aws/modules/2-nbs7/eks-nbs/outputs.tf
+++ b/terraform/aws/modules/2-nbs7/eks-nbs/outputs.tf
@@ -41,5 +41,5 @@ output "readonly_role_arns" {
 
 output "otel_collector_role_arn" {
   description = "OTEL Collector IRSA role ARN — pass to helm install via --set serviceAccount.annotations"
-  value       = var.create_otel_collector_irsa ? module.otel_collector_irsa_role.iam_role_arn : null
+  value       = var.create_otel_collector_irsa ? module.otel_collector_irsa_role.arn : null
 }


### PR DESCRIPTION
When `create_otel_collector_irsa` or `create_datacompare_irsa` are set to false, terraform will error with 

```
│ Error: Invalid index
│ 
│   on .terraform/modules/main.eks_nbs/terraform/aws/modules/2-nbs7/eks-nbs/irsa.tf line 53, in module "otel_collector_irsa_role":
│   53:     policy = aws_iam_policy.otel_collector_irsa_policy[0].arn
│     ├────────────────
│     │ aws_iam_policy.otel_collector_irsa_policy is empty tuple
│ 
│ The given key does not identify an element in this collection value: the collection has no elements.


```

This PR adds a try function that sets a default of null when the `create` variable is false.