### PR TITLE
MSK cluster should use its configuration latest revision

### DIFF
--- a/terraform/aws/modules/2-nbs7/msk/main.tf
+++ b/terraform/aws/modules/2-nbs7/msk/main.tf
@@ -131,7 +131,7 @@ resource "aws_msk_cluster" "this" {
 
   configuration_info {
     arn      = aws_msk_configuration.msk_configuration_environment[0].arn
-    revision = 1
+    revision = aws_msk_configuration.msk_configuration_environment[0].latest_revision
   }
 
   broker_node_group_info {


### PR DESCRIPTION
This PR is needed in order for the change in this `main.tf` file to the `aws_msk_configuration` resource in the https://github.com/CDCgov/NEDSS-Infrastructure/pull/283/ PR to take effect.