### PR TITLE
Minor fixes to the MSK module

### DIFF
--- a/terraform/aws/modules/2-nbs7/msk/README.md
+++ b/terraform/aws/modules/2-nbs7/msk/README.md
@@ -11,7 +11,8 @@ Below are the input parameter variables for the MSK:
 | Key            | Type           | Default        | Description    |
 | -------------- | -------------- | -------------- | -------------- |
 | create_msk | bool | true | Create msk cluser and required resources? |
-| environment | string | `development` | The environment, either 'development' or 'production'. This module creates 2 kafka.t3.small brokers for 'development', otherwise 3 kafka.m5.large brokers are created. |
+| environment | string | `development` | The environment, either 'development' or 'production'. This module creates kafka.t3.small brokers for 'development', otherwise kafka.m5.large brokers are created. |
+| additional_brokers_to_create | number | `0` | How many additional brokers to create - beyond two for 'development' or otherwise three. |
 | msk_ebs_volume_size | number |  | EBS volume size for the MSK broker nodes in GB |
 | msk_security_groups | list(string) |  | A list of security groups to use for the MSK cluster  |
 | msk_subnet_ids | list(string) |  | The list of subnets to use for the MSK cluster. There must be 2+ subnets for a 'development' environment, otherwise 3+ subnets. |

--- a/terraform/aws/modules/2-nbs7/msk/README.md
+++ b/terraform/aws/modules/2-nbs7/msk/README.md
@@ -4,23 +4,21 @@
 
 This module is used to deploy and configure an Amazon Managed Streaming for Apache Kafka (MSK). 
 
-
 ## Inputs
 
 Below are the input parameter variables for the MSK:
 
-| Key | Type | Default | Description |
+| Key            | Type           | Default        | Description    |
 | -------------- | -------------- | -------------- | -------------- |
 | create_msk | bool | true | Create msk cluser and required resources? |
-| environment | string | `development` | The environment, either 'development' or 'production' |
-| modern-cidr | string |  | VPC CIDR to be used with cluster SG |
+| environment | string | `development` | The environment, either 'development' or 'production'. This module creates 2 kafka.t3.small brokers for 'development', otherwise 3 kafka.m5.large brokers are created. |
 | msk_ebs_volume_size | number |  | EBS volume size for the MSK broker nodes in GB |
 | msk_security_groups | list(string) |  | A list of security groups to use for the MSK cluster  |
-| msk_subnet_ids | list(string) |  | A list of subnets to use for the MSK cluster. Must contain two subnets for 'development' otherwise three subnets for 'production', in order to match the number of brokers.  |
-| resource_prefix | string |  | Prefix for resource names |
+| msk_subnet_ids | list(string) |  | The list of subnets to use for the MSK cluster. There must be 2+ subnets for a 'development' environment, otherwise 3+ subnets. |
+| resource_prefix | string | `cdc-nbs` | Prefix for resource names |
 | vpc_id | string |  | VPC Id to be used with cluster |
-| vpn-cidr | string |  | VPN VPC CIDR to be used with cluster SG |
-
+| cidr_blocks | list(any) |  |  |
+| kafka_version | string | `3.6.0` | Version of Kafka to be deployed in cluster |
 
 ## Outputs
 

--- a/terraform/aws/modules/2-nbs7/msk/main.tf
+++ b/terraform/aws/modules/2-nbs7/msk/main.tf
@@ -12,7 +12,7 @@ locals {
   # For production: typically at minimum use kafka.m5.large, and for high-throughput environments consider using kafka.m5.2xlarge or higher.
   broker_instance_type = var.environment == "development" ? "kafka.t3.small" : "kafka.m5.large"
 
-  number_of_brokers = var.environment == "development" ? 2 : 3
+  number_of_brokers = var.environment == "development" ? (2 + var.additional_brokers_to_create) : (3 + var.additional_brokers_to_create)
 }
 
 # Create an IAM role for MSK
@@ -203,7 +203,7 @@ locals {
   #    ** If you set MinISR >= RF then you'll receive a notification in AWS User Notifications stating your cluster does not have high availability and advising you to change your MSK cluster configuration so that MinISR is at most RF - 1.
   # Guidance for choosing values for configuration settings in the server.properties file:
   #  * For production, as noted on the "Best practices for Standard brokers" page mentioned above, set RF to 3. (There might be other changes needed to this Terraform module for it to be used by a production environment, such as possibly setting num.partitions=3 and auto.create.topics.enable=false.)
-  #  * For non-production, if minimizing resource usage is more of a priority to you than simulating production behavior, then set RF=2 (and MinISR=1). Two AZs can be sufficient to achieve high availability, so long as MinISR is at most RF - 1.
+  #  * For non-production, if minimizing resource usage is more of a priority to you than simulating production behavior, then if 2 brokers is sufficient to support your number of partitions then set RF=2 (and MinISR=1). This can be sufficient to achieve high availability, so long as MinISR is at most RF - 1.
   #
   # More considerations for production environments:
   #  * https://repost.aws/knowledge-center/msk-avoid-disruption-during-patching

--- a/terraform/aws/modules/2-nbs7/msk/main.tf
+++ b/terraform/aws/modules/2-nbs7/msk/main.tf
@@ -1,8 +1,18 @@
 locals {
   module_name          = "msk"
-  module_serial_number = "2026-04-30_01" # Update with each commit? Date plus two digit increment.
-  instance_type        = var.environment == "development" ? "kafka.t3.small" : "kafka.m5.large"
-  number_of_brokers    = var.environment == "development" ? 2 : 3
+  module_serial_number = "2026-05-06_01" # Update with each commit? Date plus two digit increment.
+
+  # The "Best practices for Standard brokers" page (https://docs.aws.amazon.com/msk/latest/developerguide/bestpractices.html) specifies how many partitions at most there should be per broker, for each broker size (https://docs.aws.amazon.com/msk/latest/developerguide/broker-instance-sizes.html).
+  # That page states the "recommended number of partitions are not enforced", but when running a `terraform apply` command to step-up your MSK cluster to a new configuration
+  # revision, if your cluster is not in compliance with the recommendation then the command will fail with:
+  #   "api error HighPartitionCountException: The number of partitions per broker is above the recommended limit. Add more brokers and rearrange the partitions per broker to be below the recommended limit, then retry the request"
+  # Other options to resolve that error (by getting the number of partitions in your cluster below the limit) is to choose a larger broker size, or to delete unneeded topics.
+  # To get the number of partitions in your cluster: in the AWS Management Console go to CloudWatch, All metrics, search for "AWS/Kafka", click "Kafka > Broker ID, Cluster Name", and filter on your cluster name and on the PartitionCount metric.
+  #  * That metric is what AWS uses to determine whether the limit is exceeded, and when you make a change to your cluster such as deleting topics it can take up to 10 metrics for that metric to be updated accordingly.
+  # For production: typically at minimum use kafka.m5.large, and for high-throughput environments consider using kafka.m5.2xlarge or higher.
+  broker_instance_type = var.environment == "development" ? "kafka.t3.small" : "kafka.m5.large"
+
+  number_of_brokers = var.environment == "development" ? 2 : 3
 }
 
 # Create an IAM role for MSK
@@ -135,8 +145,10 @@ resource "aws_msk_cluster" "this" {
   }
 
   broker_node_group_info {
-    instance_type  = local.instance_type
+    instance_type = local.broker_instance_type
+
     client_subnets = var.msk_subnet_ids
+
     #security_groups = var.msk_security_groups
     security_groups = [aws_security_group.msk_cluster_sg[0].id]
     storage_info {
@@ -182,18 +194,29 @@ resource "aws_msk_cluster" "this" {
 locals {
   # Reference info: https://docs.confluent.io/platform/current/installation/configuration/index.html
   #
-  # For production, as noted on https://docs.aws.amazon.com/msk/latest/developerguide/bestpractices.html it's a best practice to set RF (Replication Factor) to 3, and set MinISR (min.insync.replicas) to at most RF - 1.
-  # For non-production, if minimizing resource usage is more of a priority to you than simulating production behavior, then set MinISR=1 and RF=2.
-  # Note that if you are using AWS MSK and if you set MinISR >= RF then you'll receive a notification in AWS User Notifications advising you to change your configuration so that MinISR is at most RF - 1.
+  # Things to note about ensuring high availability of your Kafka cluster:
+  #  * Partitions are for scalability and performance (they split a topic's data across multiple brokers), whereas replicas (i.e. a copy of a topic partition stored on a broker) are for availability and fault tolerance.
+  #  * num.partitions is the number of partitions for each topic.
+  #  * RF (Replication Factor) is the number of replicas for each topic. RF is generally set to at least 2, and set to 3 for production.
+  #  * MinISR (min.insync.replicas) sets the minimum number of in-sync replicas (ISR) that must acknowledge a write for it to be considered successful.
+  #    ** It's a best practice to set MinISR (min.insync.replicas) to at most RF - 1 in order to preserve high availability. A standard resilient configuration for a topic with RF=3 is to set MinISR=2.
+  #    ** If you set MinISR >= RF then you'll receive a notification in AWS User Notifications stating your cluster does not have high availability and advising you to change your MSK cluster configuration so that MinISR is at most RF - 1.
+  # Guidance for choosing values for configuration settings in the server.properties file:
+  #  * For production, as noted on the "Best practices for Standard brokers" page mentioned above, set RF to 3. (There might be other changes needed to this Terraform module for it to be used by a production environment, such as possibly setting num.partitions=3 and auto.create.topics.enable=false.)
+  #  * For non-production, if minimizing resource usage is more of a priority to you than simulating production behavior, then set RF=2 (and MinISR=1). Two AZs can be sufficient to achieve high availability, so long as MinISR is at most RF - 1.
   #
   # More considerations for production environments:
   #  * https://repost.aws/knowledge-center/msk-avoid-disruption-during-patching
   #  * https://docs.aws.amazon.com/securityhub/latest/userguide/msk-controls.html
+
+  min_ISR = local.number_of_brokers - 1
+
+  # unclean.leader.election.enable should almost always be set to false, to prevent out-of-sync replicas from becoming leaders (which could cause silent data loss).
   server_properties = <<PROPERTIES
 auto.create.topics.enable = true
 delete.topic.enable = true
 default.replication.factor=${local.number_of_brokers}
-min.insync.replicas=1
+min.insync.replicas=${local.min_ISR}
 num.io.threads=8
 num.network.threads=5
 num.partitions=1
@@ -202,7 +225,7 @@ replica.lag.time.max.ms=30000
 socket.receive.buffer.bytes=102400
 socket.request.max.bytes=104857600
 socket.send.buffer.bytes=102400
-unclean.leader.election.enable=true
+unclean.leader.election.enable=false
 zookeeper.session.timeout.ms=18000
 offsets.topic.replication.factor=${local.number_of_brokers}
 transaction.state.log.replication.factor=${local.number_of_brokers}

--- a/terraform/aws/modules/2-nbs7/msk/variables.tf
+++ b/terraform/aws/modules/2-nbs7/msk/variables.tf
@@ -11,13 +11,24 @@ variable "create_msk" {
 }
 
 variable "environment" {
-  description = "The environment, either 'development' or 'production'"
+  type        = string
+  description = "The environment, either 'development' or 'production'. This module creates 2 kafka.t3.small brokers for 'development', otherwise 3 kafka.m5.large brokers are created."
   default     = "development"
+  validation { # Note that `terraform validate` can only perform some checks, but all validation rules will be evaluated by `terraform plan`.
+    condition     = contains(["development", "production"], var.environment)
+    error_message = "This variable must be development or production."
+  }
 }
 
 variable "msk_subnet_ids" {
-  description = "A list of subnets to use for the MSK cluster"
+  description = "The list of subnets to use for the MSK cluster. There must be 2+ subnets for a 'development' environment, otherwise 3+ subnets."
   type        = list(string)
+  validation {
+    # The number of subnets determines how many AZs (Availability Zones) the cluster uses. AWS requires at least one broker per AZ. Thus checking the number of subnets here ensures the implementation of this module will create enough brokers.
+    # Note that there is no advantage to providing more than the minimum required number of subnets, because this module only creates 2 or 3 brokers.
+    condition     = (var.environment == "development" && length(var.msk_subnet_ids) >= 2) || (length(var.msk_subnet_ids) >= 3)
+    error_message = "There must be 2+ subnets for a 'development' environment, otherwise 3+ subnets."
+  }
 }
 
 variable "msk_ebs_volume_size" {

--- a/terraform/aws/modules/2-nbs7/msk/variables.tf
+++ b/terraform/aws/modules/2-nbs7/msk/variables.tf
@@ -12,7 +12,7 @@ variable "create_msk" {
 
 variable "environment" {
   type        = string
-  description = "The environment, either 'development' or 'production'. This module creates 2 kafka.t3.small brokers for 'development', otherwise 3 kafka.m5.large brokers are created."
+  description = "The environment, either 'development' or 'production'. This module creates kafka.t3.small brokers for 'development', otherwise kafka.m5.large brokers are created."
   default     = "development"
   validation { # Note that `terraform validate` can only perform some checks, but all validation rules will be evaluated by `terraform plan`.
     condition     = contains(["development", "production"], var.environment)
@@ -25,10 +25,17 @@ variable "msk_subnet_ids" {
   type        = list(string)
   validation {
     # The number of subnets determines how many AZs (Availability Zones) the cluster uses. AWS requires at least one broker per AZ. Thus checking the number of subnets here ensures the implementation of this module will create enough brokers.
-    # Note that there is no advantage to providing more than the minimum required number of subnets, because this module only creates 2 or 3 brokers.
+    # Note that there is no advantage to providing more than the minimum required number of subnets, because this module only creates 2 or 3 brokers (plus additional_brokers_to_create).
+    # If you add a subnet to an existing MSK cluster that will require the cluster to be re-created which causes the topics/data in the cluster to be deleted.
     condition     = (var.environment == "development" && length(var.msk_subnet_ids) >= 2) || (length(var.msk_subnet_ids) >= 3)
     error_message = "There must be 2+ subnets for a 'development' environment, otherwise 3+ subnets."
   }
+}
+
+variable "additional_brokers_to_create" {
+  type        = number
+  description = "How many additional brokers to create - beyond two for 'development' or otherwise three."
+  default     = 0
 }
 
 variable "msk_ebs_volume_size" {


### PR DESCRIPTION
The primary purpose of this PR is to add validation checks to some variables for the `msk` module. 

The only minor functional changes made by this PR are: 
- to ensure that `MinISR` is set to one less than `RF`
- to change `unclean.leader.election.enable` to `false`
- adding additional_brokers_to_create