### PR TITLE
feat(azure): resource group module

### DIFF
--- a/terraform/azure/modules/0_landing_zone/resource_group/README.md
+++ b/terraform/azure/modules/0_landing_zone/resource_group/README.md
@@ -1,0 +1,40 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.13.3 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=4.68, <5.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >=4.68, <5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether to create the resource group | `bool` | `true` | no |
+| <a name="input_location"></a> [location](#input\_location) | The Azure region (e.g., East US) | `string` | `"East US"` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_id"></a> [id](#output\_id) | Resource group ID |
+| <a name="output_location"></a> [location](#output\_location) | Resource group location |
+| <a name="output_name"></a> [name](#output\_name) | Resource group name |
+<!-- END_TF_DOCS -->

--- a/terraform/azure/modules/0_landing_zone/resource_group/main.tf
+++ b/terraform/azure/modules/0_landing_zone/resource_group/main.tf
@@ -1,0 +1,6 @@
+resource "azurerm_resource_group" "this" {
+  count = var.enabled ? 1 : 0
+
+  name     = var.resource_group_name
+  location = var.location
+}

--- a/terraform/azure/modules/0_landing_zone/resource_group/outputs.tf
+++ b/terraform/azure/modules/0_landing_zone/resource_group/outputs.tf
@@ -1,0 +1,14 @@
+output "id" {
+  description = "Resource group ID"
+  value       = try(azurerm_resource_group.this[0].id, null)
+}
+
+output "name" {
+  description = "Resource group name"
+  value       = try(azurerm_resource_group.this[0].name, null)
+}
+
+output "location" {
+  description = "Resource group location"
+  value       = try(azurerm_resource_group.this[0].location, null)
+}

--- a/terraform/azure/modules/0_landing_zone/resource_group/providers.tf
+++ b/terraform/azure/modules/0_landing_zone/resource_group/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.13.3"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=4.68, <5.0"
+    }
+  }
+}

--- a/terraform/azure/modules/0_landing_zone/resource_group/variables.tf
+++ b/terraform/azure/modules/0_landing_zone/resource_group/variables.tf
@@ -1,0 +1,17 @@
+variable "enabled" {
+  description = "Whether to create the resource group"
+  type        = bool
+  default     = true
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group"
+  type        = string
+}
+
+variable "location" {
+  description = "The Azure region (e.g., East US)"
+  type        = string
+  default     = "East US"
+}
+


### PR DESCRIPTION
This PR adds a new terraform module for the optional creation of an Azure resource group

```
Terraform will perform the following actions:

  # module.main.module.resource_group.azurerm_resource_group.this[0] will be created
  + resource "azurerm_resource_group" "this" {
      + id       = (known after apply)
      + location = "eastus"
      + name     = "nedss-example"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```