### PR TITLE
feat(azure): vnet submodule for creating subnets

### DIFF
--- a/terraform/azure/modules/0-landing-zone/vnet/subnet/main.tf
+++ b/terraform/azure/modules/0-landing-zone/vnet/subnet/main.tf
@@ -1,0 +1,28 @@
+resource "azurerm_subnet" "this" {
+  name                 = var.subnet.name
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = var.virtual_network_name
+  address_prefixes     = var.subnet.address_prefixes
+
+  private_endpoint_network_policies             = var.subnet.private_endpoint_network_policies
+  private_link_service_network_policies_enabled = var.subnet.private_link_service_network_policies_enabled
+
+  service_endpoints = length(var.subnet.service_endpoints_with_location) > 0 ? distinct([
+    for ep in var.subnet.service_endpoints_with_location : ep.service
+  ]) : []
+
+  service_endpoint_policy_ids = var.subnet.service_endpoint_policy_ids
+
+  dynamic "delegation" {
+    for_each = var.subnet.delegations
+
+    content {
+      name = delegation.value.name
+
+      service_delegation {
+        name    = delegation.value.service_delegation.name
+        actions = delegation.value.service_delegation.actions
+      }
+    }
+  }
+}

--- a/terraform/azure/modules/0-landing-zone/vnet/subnet/outputs.tf
+++ b/terraform/azure/modules/0-landing-zone/vnet/subnet/outputs.tf
@@ -1,0 +1,14 @@
+output "subnet_id" {
+  description = "ID of the subnet"
+  value       = azurerm_subnet.this.id
+}
+
+output "subnet_name" {
+  description = "Name of the subnet"
+  value       = azurerm_subnet.this.name
+}
+
+output "subnet" {
+  description = "Full subnet resource"
+  value       = azurerm_subnet.this
+}

--- a/terraform/azure/modules/0-landing-zone/vnet/subnet/variables.tf
+++ b/terraform/azure/modules/0-landing-zone/vnet/subnet/variables.tf
@@ -1,0 +1,35 @@
+variable "resource_group_name" {
+  description = "Name of the resource group"
+  type        = string
+}
+
+variable "virtual_network_name" {
+  description = "Name of the virtual network"
+  type        = string
+}
+
+variable "subnet" {
+  description = "Subnet configuration"
+  type = object({
+    name             = string
+    address_prefixes = list(string)
+
+    private_endpoint_network_policies             = optional(string, "Enabled")
+    private_link_service_network_policies_enabled = optional(bool, true)
+
+    service_endpoints_with_location = optional(list(object({
+      service   = string
+      locations = list(string)
+    })), [])
+
+    service_endpoint_policy_ids = optional(list(string), [])
+
+    delegations = optional(list(object({
+      name = string
+      service_delegation = object({
+        name    = string
+        actions = optional(list(string), [])
+      })
+    })), [])
+  })
+}


### PR DESCRIPTION
This PR creates a module in `terraform/azure/modules/0-landing-zone/vnet` to configure a subnet.  It reduces terraform drift by declaring the subnet with the `azurerm` prvider instead of `azapi`, which the current module uses and will report resources changed outside of terraform when the hdi-kafka module has been created due to the association of a security group.