### PR TITLE
feat(azure): Add enabled flag to private dns zone

### DIFF
--- a/terraform/azure/modules/0-landing-zone/private-dns-zone/README.md
+++ b/terraform/azure/modules/0-landing-zone/private-dns-zone/README.md
@@ -1,0 +1,42 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.13.3 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=4.68, <5.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >=4.68, <5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [azurerm_private_dns_zone.private](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.private](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Enable the module | `bool` | `true` | no |
+| <a name="input_private_dns_zone_name"></a> [private\_dns\_zone\_name](#input\_private\_dns\_zone\_name) | Name for the private dns zone | `string` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group | `string` | n/a | yes |
+| <a name="input_vnet_id"></a> [vnet\_id](#input\_vnet\_id) | vnet id | `string` | n/a | yes |
+| <a name="input_vnet_name"></a> [vnet\_name](#input\_vnet\_name) | vnet name | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_private_dns_zone_id"></a> [private\_dns\_zone\_id](#output\_private\_dns\_zone\_id) | n/a |
+<!-- END_TF_DOCS -->

--- a/terraform/azure/modules/0-landing-zone/private-dns-zone/main.tf
+++ b/terraform/azure/modules/0-landing-zone/private-dns-zone/main.tf
@@ -1,12 +1,14 @@
 resource "azurerm_private_dns_zone" "private" {
+  count               = var.enabled ? 1 : 0
   name                = var.private_dns_zone_name
   resource_group_name = data.azurerm_resource_group.rg.name
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "private" {
-  name                  = "${var.vnet_name}-dns-link"
+  count                 = var.enabled ? 1 : 0
+  name                  = "${var.vnet_name}-private-dns-link"
   resource_group_name   = var.resource_group_name
-  private_dns_zone_name = azurerm_private_dns_zone.private.name
+  private_dns_zone_name = azurerm_private_dns_zone.private[count.index].name
   virtual_network_id    = var.vnet_id
   registration_enabled  = true
 }

--- a/terraform/azure/modules/0-landing-zone/private-dns-zone/outputs.tf
+++ b/terraform/azure/modules/0-landing-zone/private-dns-zone/outputs.tf
@@ -1,0 +1,4 @@
+output "private_dns_zone_id" {
+  value = try(azurerm_private_dns_zone.private[0].id, "Module not enabled")
+}
+

--- a/terraform/azure/modules/0-landing-zone/private-dns-zone/variables.tf
+++ b/terraform/azure/modules/0-landing-zone/private-dns-zone/variables.tf
@@ -1,3 +1,9 @@
+variable "enabled" {
+  type        = bool
+  description = "Enable the module"
+  default     = true
+}
+
 variable "resource_group_name" {
   description = "The name of the resource group"
   type        = string

--- a/terraform/azure/modules/0-landing-zone/public-dns-zone/README.md
+++ b/terraform/azure/modules/0-landing-zone/public-dns-zone/README.md
@@ -1,13 +1,16 @@
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.13.3 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=4.68, <5.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| ---- | ------- |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >=4.68, <5.0 |
 
 ## Modules
 
@@ -16,17 +19,20 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [azurerm_dns_zone.public](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_zone) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_public_domain_name"></a> [public\_domain\_name](#input\_public\_domain\_name) | The root domain (e.g., example.com) | `string` | n/a | yes |
-| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group name | `string` | n/a | yes |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Enable the module | `bool` | `true` | no |
+| <a name="input_public_domain_name"></a> [public\_domain\_name](#input\_public\_domain\_name) | The root domain (e.g., example.com) | `string` | `""` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group name | `string` | `""` | no |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_dns_zone_id"></a> [dns\_zone\_id](#output\_dns\_zone\_id) | n/a |
 <!-- END_TF_DOCS -->


### PR DESCRIPTION
This PR adds the enabled flag to the `terraform/azure/modules/0-landing-zone/private-dns-zone` module and updates the README for the `terraform/azure/modules/0-landing-zone/public-dns-zone` module