### PR TITLE
feat(azure): Key Vault module

### DIFF
--- a/terraform/azure/modules/0-landing-zone/keyvault/README.md
+++ b/terraform/azure/modules/0-landing-zone/keyvault/README.md
@@ -1,0 +1,64 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=4.68, <5.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >=4.68, <5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [azurerm_key_vault.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
+| [azurerm_key_vault_access_policy.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_private_endpoint.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
+| [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_access_policies"></a> [access\_policies](#input\_access\_policies) | Map of legacy access policies. Applies only when<br/>enable\_rbac\_authorization = false.<br/>Prefer RBAC for new deployments; use this only to support existing<br/>vaults that have not been migrated.<br/><br/>Map key: an arbitrary unique label.<br/>Map value fields:<br/>- object\_id:               (required) AAD object ID of the principal.<br/>- tenant\_id:               (optional) Tenant ID; defaults to<br/>                           var.tenant\_id or the current tenant.<br/>- key\_permissions:         (optional) Permitted key operations.<br/>- secret\_permissions:      (optional) Permitted secret operations.<br/>- certificate\_permissions: (optional) Permitted certificate ops.<br/>- storage\_permissions:     (optional) Permitted storage account ops. | <pre>map(object({<br/>    object_id               = string<br/>    tenant_id               = optional(string)<br/>    key_permissions         = optional(list(string), [])<br/>    secret_permissions      = optional(list(string), [])<br/>    certificate_permissions = optional(list(string), [])<br/>    storage_permissions     = optional(list(string), [])<br/>  }))</pre> | `{}` | no |
+| <a name="input_contacts"></a> [contacts](#input\_contacts) | List of certificate contacts notified on certificate lifecycle events<br/>(e.g. expiry, auto-renewal failures). At least an email is required;<br/>name and phone are optional. | <pre>list(object({<br/>    email = string<br/>    name  = optional(string)<br/>    phone = optional(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_enable_rbac_authorization"></a> [enable\_rbac\_authorization](#input\_enable\_rbac\_authorization) | When true (recommended), data-plane access is governed by Azure RBAC<br/>role assignments, replacing the legacy access-policy model.<br/>Set to false only when migrating existing vaults that rely on<br/>access policies and have not yet been converted to RBAC. | `bool` | `true` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Enable or disable the entire module without removing it. | `bool` | `true` | no |
+| <a name="input_enabled_for_deployment"></a> [enabled\_for\_deployment](#input\_enabled\_for\_deployment) | Allow Azure Virtual Machines to retrieve certificates stored as<br/>secrets in this Key Vault during VM provisioning or extension runs. | `bool` | `false` | no |
+| <a name="input_enabled_for_disk_encryption"></a> [enabled\_for\_disk\_encryption](#input\_enabled\_for\_disk\_encryption) | Allow Azure Disk Encryption to retrieve secrets and unwrap keys<br/>stored in this Key Vault for encrypting VM OS and data disks. | `bool` | `false` | no |
+| <a name="input_enabled_for_template_deployment"></a> [enabled\_for\_template\_deployment](#input\_enabled\_for\_template\_deployment) | Allow Azure Resource Manager template deployments to retrieve<br/>secrets from this Key Vault using the reference() function. | `bool` | `false` | no |
+| <a name="input_firewall_ip_rules"></a> [firewall\_ip\_rules](#input\_firewall\_ip\_rules) | List of IPv4 addresses or CIDR ranges allowed through the Key Vault<br/>firewall. Providing any entry sets the network ACL default action<br/>to "Deny" and bypass to "AzureServices", so only listed ranges and<br/>trusted Azure services can reach the vault.<br/><br/>Examples: ["203.0.113.10/32", "198.51.100.0/24"]<br/><br/>Note: "0.0.0.0/0" permits all public IPs and is not recommended<br/>for production environments. | `list(string)` | `[]` | no |
+| <a name="input_firewall_virtual_network_subnet_ids"></a> [firewall\_virtual\_network\_subnet\_ids](#input\_firewall\_virtual\_network\_subnet\_ids) | List of subnet resource IDs granted access via VNet service<br/>endpoints. The subnets must have the<br/>"Microsoft.KeyVault" service endpoint enabled.<br/>Example: ["/subscriptions/.../subnets/app-subnet"] | `list(string)` | `[]` | no |
+| <a name="input_location"></a> [location](#input\_location) | Azure region where the Key Vault will be created (e.g. 'eastus'). | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the Key Vault. Must be globally unique across all of Azure.<br/>Constraints: 3-24 characters, alphanumeric and hyphens only,<br/>must start with a letter, and cannot end with a hyphen. | `string` | n/a | yes |
+| <a name="input_private_endpoint"></a> [private\_endpoint](#input\_private\_endpoint) | Optional configuration for a Private Endpoint that places the Key<br/>Vault on a VNet, removing the need for public internet access.<br/>When provided, consider setting public\_network\_access\_enabled = false.<br/><br/>Fields:<br/>- subnet\_id:            (required) Resource ID of the target subnet.<br/>                        The subnet must not have a network policy<br/>                        that blocks private endpoints.<br/>- name:                 (optional) Name for the endpoint resource;<br/>                        defaults to "<vault-name>-pe".<br/>- connection\_name:      (optional) Name for the private service<br/>                        connection; defaults to "<vault-name>-psc".<br/>- private\_dns\_zone\_ids: (optional) List of private DNS zone resource<br/>                        IDs to register the endpoint in, typically<br/>                        ["...privatelink.vaultcore.azure.net"]. | <pre>object({<br/>    subnet_id            = string<br/>    name                 = optional(string)<br/>    connection_name      = optional(string)<br/>    private_dns_zone_ids = optional(list(string), [])<br/>  })</pre> | `null` | no |
+| <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled) | Allow access to the Key Vault over the public internet.<br/>Set to false when all access is routed through a private endpoint;<br/>leaving this true while using private endpoints permits both paths. | `bool` | `true` | no |
+| <a name="input_purge_protection_enabled"></a> [purge\_protection\_enabled](#input\_purge\_protection\_enabled) | Prevent permanent deletion of the vault and its objects until the<br/>soft-delete retention period expires. Once enabled this cannot be<br/>disabled. Strongly recommended for production workloads. | `bool` | `true` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the resource group to deploy the Key Vault into. | `string` | n/a | yes |
+| <a name="input_role_assignments"></a> [role\_assignments](#input\_role\_assignments) | Map of Azure RBAC role assignments for the Key Vault data plane.<br/>Applies only when enable\_rbac\_authorization = true (the default).<br/><br/>Map key: an arbitrary unique label used as the Terraform resource key.<br/>Map value fields:<br/>- principal\_id:   (required) Object ID of the AAD user, group, or<br/>                  service principal to assign the role to.<br/>- role:           (required) Built-in role name or full resource ID<br/>                  of a custom role definition.<br/>                  Common built-in roles:<br/>                    "Key Vault Administrator"<br/>                    "Key Vault Secrets Officer"<br/>                    "Key Vault Secrets User"<br/>                    "Key Vault Crypto Officer"<br/>                    "Key Vault Crypto User"<br/>                    "Key Vault Reader"<br/>                    "Key Vault Certificate User"<br/>- principal\_type: (optional) "User", "Group", "ServicePrincipal",<br/>                  or "Device". Supplying this prevents an extra AAD<br/>                  lookup and reduces apply time.<br/>- description:    (optional) Free-text note stored on the assignment<br/>                  for auditing purposes. | <pre>map(object({<br/>    principal_id   = string<br/>    role           = string<br/>    principal_type = optional(string)<br/>    description    = optional(string)<br/>  }))</pre> | `{}` | no |
+| <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name) | Pricing tier for the Key Vault.<br/>- "standard": software-protected keys, suitable for most workloads.<br/>- "premium":  adds HSM-backed keys for compliance or high-security use. | `string` | `"standard"` | no |
+| <a name="input_soft_delete_retention_days"></a> [soft\_delete\_retention\_days](#input\_soft\_delete\_retention\_days) | Number of days soft-deleted vaults and their contents are retained<br/>before they can be purged. Accepted range: 7-90 days.<br/>Microsoft recommends 90 days for production environments. | `number` | `90` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Map of tags applied to all resources created by this module.<br/>Use to enforce organisational tagging policies (e.g. cost centre,<br/>environment, owner).<br/>Example: { environment = "production", cost\_centre = "platform" } | `map(string)` | `{}` | no |
+| <a name="input_tenant_id"></a> [tenant\_id](#input\_tenant\_id) | Azure Active Directory tenant ID that owns the Key Vault.<br/>Defaults to the tenant of the currently authenticated client.<br/>Override when deploying into a tenant different from the one<br/>used for authentication. | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_id"></a> [id](#output\_id) | Resource ID of the Key Vault. |
+| <a name="output_name"></a> [name](#output\_name) | Name of the Key Vault. |
+| <a name="output_private_endpoint_id"></a> [private\_endpoint\_id](#output\_private\_endpoint\_id) | Resource ID of the private endpoint, if created. |
+| <a name="output_private_endpoint_ip"></a> [private\_endpoint\_ip](#output\_private\_endpoint\_ip) | Private IP address of the private endpoint, if created. |
+| <a name="output_tenant_id"></a> [tenant\_id](#output\_tenant\_id) | Tenant ID the Key Vault belongs to. |
+| <a name="output_uri"></a> [uri](#output\_uri) | URI of the Key Vault (used to access vault objects). |
+<!-- END_TF_DOCS -->

--- a/terraform/azure/modules/0-landing-zone/keyvault/data.tf
+++ b/terraform/azure/modules/0-landing-zone/keyvault/data.tf
@@ -1,0 +1,1 @@
+data "azurerm_client_config" "current" {}

--- a/terraform/azure/modules/0-landing-zone/keyvault/main.tf
+++ b/terraform/azure/modules/0-landing-zone/keyvault/main.tf
@@ -1,0 +1,85 @@
+resource "azurerm_key_vault" "this" {
+  count               = var.enabled ? 1 : 0
+  name                = var.name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  tenant_id           = var.tenant_id != null ? var.tenant_id : data.azurerm_client_config.current.tenant_id
+  sku_name            = var.sku_name
+
+  enabled_for_deployment          = var.enabled_for_deployment
+  enabled_for_disk_encryption     = var.enabled_for_disk_encryption
+  enabled_for_template_deployment = var.enabled_for_template_deployment
+  rbac_authorization_enabled      = var.enable_rbac_authorization
+
+  purge_protection_enabled      = var.purge_protection_enabled
+  soft_delete_retention_days    = var.soft_delete_retention_days
+  public_network_access_enabled = var.public_network_access_enabled
+
+  dynamic "network_acls" {
+    for_each = length(var.firewall_ip_rules) > 0 || length(var.firewall_virtual_network_subnet_ids) > 0 ? [1] : []
+    content {
+      bypass                     = "AzureServices"
+      default_action             = "Deny"
+      ip_rules                   = var.firewall_ip_rules
+      virtual_network_subnet_ids = var.firewall_virtual_network_subnet_ids
+    }
+  }
+
+
+  tags = var.tags
+}
+
+# Access policies (only used when enable_rbac_authorization = false)
+resource "azurerm_key_vault_access_policy" "this" {
+  for_each = var.enabled && var.enable_rbac_authorization ? {} : var.access_policies
+
+  key_vault_id = azurerm_key_vault.this[0].id
+  tenant_id    = lookup(each.value, "tenant_id", data.azurerm_client_config.current.tenant_id)
+  object_id    = each.value.object_id
+
+  key_permissions         = lookup(each.value, "key_permissions", [])
+  secret_permissions      = lookup(each.value, "secret_permissions", [])
+  certificate_permissions = lookup(each.value, "certificate_permissions", [])
+  storage_permissions     = lookup(each.value, "storage_permissions", [])
+}
+
+# RBAC role assignments (only used when enable_rbac_authorization = true)
+resource "azurerm_role_assignment" "this" {
+  for_each = var.enabled && var.enable_rbac_authorization ? var.role_assignments : {}
+
+  scope          = azurerm_key_vault.this[0].id
+  principal_id   = each.value.principal_id
+  principal_type = each.value.principal_type
+  description    = each.value.description
+
+  # Accept either a plain built-in role name ("Key Vault Secrets Officer")
+  # or a full role definition resource ID for custom roles.
+  role_definition_name = can(regex("^/", each.value.role)) ? null : each.value.role
+  role_definition_id   = can(regex("^/", each.value.role)) ? each.value.role : null
+}
+
+resource "azurerm_private_endpoint" "this" {
+  count = var.enabled && var.private_endpoint != null ? 1 : 0
+
+  name                = coalesce(var.private_endpoint.name, "${var.name}-pe")
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.private_endpoint.subnet_id
+
+  private_service_connection {
+    name                           = coalesce(var.private_endpoint.connection_name, "${var.name}-psc")
+    private_connection_resource_id = azurerm_key_vault.this[count.index].id
+    subresource_names              = ["vault"]
+    is_manual_connection           = false
+  }
+
+  dynamic "private_dns_zone_group" {
+    for_each = var.private_endpoint.private_dns_zone_ids != null ? [1] : []
+    content {
+      name                 = "default"
+      private_dns_zone_ids = var.private_endpoint.private_dns_zone_ids
+    }
+  }
+
+  tags = var.tags
+}

--- a/terraform/azure/modules/0-landing-zone/keyvault/outputs.tf
+++ b/terraform/azure/modules/0-landing-zone/keyvault/outputs.tf
@@ -1,0 +1,29 @@
+output "id" {
+  description = "Resource ID of the Key Vault."
+  value       = try(azurerm_key_vault.this[0].id, "Module not enabled")
+}
+
+output "name" {
+  description = "Name of the Key Vault."
+  value       = try(azurerm_key_vault.this[0].name, "Module not enabled")
+}
+
+output "uri" {
+  description = "URI of the Key Vault (used to access vault objects)."
+  value       = try(azurerm_key_vault.this[0].vault_uri, "Module not enabled")
+}
+
+output "tenant_id" {
+  description = "Tenant ID the Key Vault belongs to."
+  value       = try(azurerm_key_vault.this[0].tenant_id, "Module not enabled")
+}
+
+output "private_endpoint_id" {
+  description = "Resource ID of the private endpoint, if created."
+  value       = try(azurerm_private_endpoint.this[0].id, null)
+}
+
+output "private_endpoint_ip" {
+  description = "Private IP address of the private endpoint, if created."
+  value       = try(azurerm_private_endpoint.this[0].private_service_connection[0].private_ip_address, null)
+}

--- a/terraform/azure/modules/0-landing-zone/keyvault/providers.tf
+++ b/terraform/azure/modules/0-landing-zone/keyvault/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=4.68, <5.0"
+    }
+  }
+}

--- a/terraform/azure/modules/0-landing-zone/keyvault/variables.tf
+++ b/terraform/azure/modules/0-landing-zone/keyvault/variables.tf
@@ -1,0 +1,346 @@
+variable "enabled" {
+  type        = bool
+  description = "Enable or disable the entire module without removing it."
+  default     = true
+}
+
+variable "name" {
+  description = <<-EOT
+    Name of the Key Vault. Must be globally unique across all of Azure.
+    Constraints: 3-24 characters, alphanumeric and hyphens only,
+    must start with a letter, and cannot end with a hyphen.
+  EOT
+  type        = string
+
+  validation {
+    condition = can(
+      regex("^[a-zA-Z][a-zA-Z0-9-]{1,22}[a-zA-Z0-9]$", var.name)
+    )
+    error_message = <<-EOT
+      Key Vault name must be 3-24 characters, start with a letter,
+      end with a letter or digit, and contain only alphanumerics and hyphens.
+    EOT
+  }
+}
+
+variable "location" {
+  description = "Azure region where the Key Vault will be created (e.g. 'eastus')."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.location)) > 0
+    error_message = "location must not be empty."
+  }
+}
+
+variable "resource_group_name" {
+  description = "Name of the resource group to deploy the Key Vault into."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.resource_group_name)) > 0
+    error_message = "resource_group_name must not be empty."
+  }
+}
+
+variable "tenant_id" {
+  description = <<-EOT
+    Azure Active Directory tenant ID that owns the Key Vault.
+    Defaults to the tenant of the currently authenticated client.
+    Override when deploying into a tenant different from the one
+    used for authentication.
+  EOT
+  type        = string
+  default     = null
+
+  validation {
+    condition = var.tenant_id == null || can(
+      regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", var.tenant_id)
+    )
+    error_message = "tenant_id must be a valid UUID (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)."
+  }
+}
+
+variable "sku_name" {
+  description = <<-EOT
+    Pricing tier for the Key Vault.
+    - "standard": software-protected keys, suitable for most workloads.
+    - "premium":  adds HSM-backed keys for compliance or high-security use.
+  EOT
+  type        = string
+  default     = "standard"
+
+  validation {
+    condition     = contains(["standard", "premium"], var.sku_name)
+    error_message = "sku_name must be either 'standard' or 'premium'."
+  }
+}
+
+variable "enabled_for_deployment" {
+  description = <<-EOT
+    Allow Azure Virtual Machines to retrieve certificates stored as
+    secrets in this Key Vault during VM provisioning or extension runs.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "enabled_for_disk_encryption" {
+  description = <<-EOT
+    Allow Azure Disk Encryption to retrieve secrets and unwrap keys
+    stored in this Key Vault for encrypting VM OS and data disks.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "enabled_for_template_deployment" {
+  description = <<-EOT
+    Allow Azure Resource Manager template deployments to retrieve
+    secrets from this Key Vault using the reference() function.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "enable_rbac_authorization" {
+  description = <<-EOT
+    When true (recommended), data-plane access is governed by Azure RBAC
+    role assignments, replacing the legacy access-policy model.
+    Set to false only when migrating existing vaults that rely on
+    access policies and have not yet been converted to RBAC.
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "purge_protection_enabled" {
+  description = <<-EOT
+    Prevent permanent deletion of the vault and its objects until the
+    soft-delete retention period expires. Once enabled this cannot be
+    disabled. Strongly recommended for production workloads.
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "soft_delete_retention_days" {
+  description = <<-EOT
+    Number of days soft-deleted vaults and their contents are retained
+    before they can be purged. Accepted range: 7-90 days.
+    Microsoft recommends 90 days for production environments.
+  EOT
+  type        = number
+  default     = 90
+
+  validation {
+    condition     = var.soft_delete_retention_days >= 7 && var.soft_delete_retention_days <= 90
+    error_message = "soft_delete_retention_days must be between 7 and 90 (inclusive)."
+  }
+}
+
+variable "public_network_access_enabled" {
+  description = <<-EOT
+    Allow access to the Key Vault over the public internet.
+    Set to false when all access is routed through a private endpoint;
+    leaving this true while using private endpoints permits both paths.
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "firewall_ip_rules" {
+  description = <<-EOT
+    List of IPv4 addresses or CIDR ranges allowed through the Key Vault
+    firewall. Providing any entry sets the network ACL default action
+    to "Deny" and bypass to "AzureServices", so only listed ranges and
+    trusted Azure services can reach the vault.
+
+    Examples: ["203.0.113.10/32", "198.51.100.0/24"]
+
+    Note: "0.0.0.0/0" permits all public IPs and is not recommended
+    for production environments.
+  EOT
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for cidr in var.firewall_ip_rules :
+      can(cidrhost(cidr, 0)) || can(cidrhost("${cidr}/32", 0))
+    ])
+    error_message = <<-EOT
+      All entries in firewall_ip_rules must be valid IPv4 addresses
+      (e.g. "203.0.113.10") or CIDR blocks (e.g. "198.51.100.0/24").
+    EOT
+  }
+}
+
+variable "firewall_virtual_network_subnet_ids" {
+  description = <<-EOT
+    List of subnet resource IDs granted access via VNet service
+    endpoints. The subnets must have the
+    "Microsoft.KeyVault" service endpoint enabled.
+    Example: ["/subscriptions/.../subnets/app-subnet"]
+  EOT
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for id in var.firewall_virtual_network_subnet_ids :
+      can(regex("^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.Network/virtualNetworks/[^/]+/subnets/[^/]+$", id))
+    ])
+    error_message = <<-EOT
+      Each entry must be a fully qualified subnet resource ID in the form:
+      /subscriptions/{sub}/resourceGroups/{rg}/providers/
+        Microsoft.Network/virtualNetworks/{vnet}/subnets/{subnet}
+    EOT
+  }
+}
+
+variable "role_assignments" {
+  description = <<-EOT
+    Map of Azure RBAC role assignments for the Key Vault data plane.
+    Applies only when enable_rbac_authorization = true (the default).
+
+    Map key: an arbitrary unique label used as the Terraform resource key.
+    Map value fields:
+    - principal_id:   (required) Object ID of the AAD user, group, or
+                      service principal to assign the role to.
+    - role:           (required) Built-in role name or full resource ID
+                      of a custom role definition.
+                      Common built-in roles:
+                        "Key Vault Administrator"
+                        "Key Vault Secrets Officer"
+                        "Key Vault Secrets User"
+                        "Key Vault Crypto Officer"
+                        "Key Vault Crypto User"
+                        "Key Vault Reader"
+                        "Key Vault Certificate User"
+    - principal_type: (optional) "User", "Group", "ServicePrincipal",
+                      or "Device". Supplying this prevents an extra AAD
+                      lookup and reduces apply time.
+    - description:    (optional) Free-text note stored on the assignment
+                      for auditing purposes.
+  EOT
+  type = map(object({
+    principal_id   = string
+    role           = string
+    principal_type = optional(string)
+    description    = optional(string)
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for k, v in var.role_assignments :
+      v.principal_id != "" && v.role != ""
+    ])
+    error_message = "Each role assignment must provide a non-empty principal_id and role."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.role_assignments :
+      v.principal_type == null ||
+      contains(["User", "Group", "ServicePrincipal", "Device"], v.principal_type)
+    ])
+    error_message = "principal_type must be one of: User, Group, ServicePrincipal, Device."
+  }
+}
+
+variable "access_policies" {
+  description = <<-EOT
+    Map of legacy access policies. Applies only when
+    enable_rbac_authorization = false.
+    Prefer RBAC for new deployments; use this only to support existing
+    vaults that have not been migrated.
+
+    Map key: an arbitrary unique label.
+    Map value fields:
+    - object_id:               (required) AAD object ID of the principal.
+    - tenant_id:               (optional) Tenant ID; defaults to
+                               var.tenant_id or the current tenant.
+    - key_permissions:         (optional) Permitted key operations.
+    - secret_permissions:      (optional) Permitted secret operations.
+    - certificate_permissions: (optional) Permitted certificate ops.
+    - storage_permissions:     (optional) Permitted storage account ops.
+  EOT
+  type = map(object({
+    object_id               = string
+    tenant_id               = optional(string)
+    key_permissions         = optional(list(string), [])
+    secret_permissions      = optional(list(string), [])
+    certificate_permissions = optional(list(string), [])
+    storage_permissions     = optional(list(string), [])
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for k, v in var.access_policies : length(trimspace(v.object_id)) > 0
+    ])
+    error_message = "Each access policy must provide a non-empty object_id."
+  }
+}
+
+variable "contacts" {
+  description = <<-EOT
+    List of certificate contacts notified on certificate lifecycle events
+    (e.g. expiry, auto-renewal failures). At least an email is required;
+    name and phone are optional.
+  EOT
+  type = list(object({
+    email = string
+    name  = optional(string)
+    phone = optional(string)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for c in var.contacts :
+      can(regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$", c.email))
+    ])
+    error_message = "Each contact must have a valid email address."
+  }
+}
+
+variable "private_endpoint" {
+  description = <<-EOT
+    Optional configuration for a Private Endpoint that places the Key
+    Vault on a VNet, removing the need for public internet access.
+    When provided, consider setting public_network_access_enabled = false.
+
+    Fields:
+    - subnet_id:            (required) Resource ID of the target subnet.
+                            The subnet must not have a network policy
+                            that blocks private endpoints.
+    - name:                 (optional) Name for the endpoint resource;
+                            defaults to "<vault-name>-pe".
+    - connection_name:      (optional) Name for the private service
+                            connection; defaults to "<vault-name>-psc".
+    - private_dns_zone_ids: (optional) List of private DNS zone resource
+                            IDs to register the endpoint in, typically
+                            ["...privatelink.vaultcore.azure.net"].
+  EOT
+  type = object({
+    subnet_id            = string
+    name                 = optional(string)
+    connection_name      = optional(string)
+    private_dns_zone_ids = optional(list(string), [])
+  })
+  default = null
+}
+
+variable "tags" {
+  description = <<-EOT
+    Map of tags applied to all resources created by this module.
+    Use to enforce organisational tagging policies (e.g. cost centre,
+    environment, owner).
+    Example: { environment = "production", cost_centre = "platform" }
+  EOT
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
This PR adds an Azure Key Vault module for storing certificates and secrets.

### Changes
- Adds an`azurerm_key_vault` resource
- Implements `azurerm_key_vault_access_policy` for standard access policies when RBAC is disabled, and implements `azurerm_role_assignment` to handle Azure RBAC role assignments when RBAC is enabled.
- Generates a dynamic network_acls block to deny public traffic by default if IP rules or subnet IDs are specified.
- Adds an optional `azurerm_private_endpoint` for private VNet connectivity.