### PR TITLE
fix(azure): update kafka storage container deprecated argument

### DIFF
--- a/terraform/azure/modules/2-nbs7/hdi-kafka/main.tf
+++ b/terraform/azure/modules/2-nbs7/hdi-kafka/main.tf
@@ -41,7 +41,7 @@ resource "azurerm_storage_account" "kafka_storage_account" {
 resource "azurerm_storage_container" "hdi_kafka_storage_container" {
   count                 = var.enabled ? 1 : 0
   name                  = "${var.resource_prefix}-hdinsight-kafka-cluster-data"
-  storage_account_name  = azurerm_storage_account.kafka_storage_account[count.index].name
+  storage_account_id    = azurerm_storage_account.kafka_storage_account[count.index].id
   container_access_type = var.container_access_type
 }
 


### PR DESCRIPTION
This PR fixes a deprecation warning in the `azurerm_storage_container.hdi_kafka_storage_container` resource

```
│   44:   storage_account_name  = azurerm_storage_account.kafka_storage_account[count.index].name
│ 
│ the `storage_account_name` property has been deprecated in favour of `storage_account_id` and will be removed in version 5.0 of the Provider.
```