### PR TITLE
Revert "fix(azure): update kafka storage container deprecated argument"

### DIFF
--- a/terraform/azure/modules/2-nbs7/hdi-kafka/main.tf
+++ b/terraform/azure/modules/2-nbs7/hdi-kafka/main.tf
@@ -41,7 +41,7 @@ resource "azurerm_storage_account" "kafka_storage_account" {
 resource "azurerm_storage_container" "hdi_kafka_storage_container" {
   count                 = var.enabled ? 1 : 0
   name                  = "${var.resource_prefix}-hdinsight-kafka-cluster-data"
-  storage_account_id    = azurerm_storage_account.kafka_storage_account[count.index].id
+  storage_account_name  = azurerm_storage_account.kafka_storage_account[count.index].name
   container_access_type = var.container_access_type
 }
 


### PR DESCRIPTION
Reverts CDCgov/NEDSS-Infrastructure#305

The first `terraform apply` succeeds, but subsequent applies will recreate resources including the Kafka cluster and storage account.  Reverting PR for now to research solution.  Deprecation warning will appear in terraform, but the module is pinned with a maximum version below 5.x (when the deprecated argument is scheduled to be removed)