### PR TITLE
feat(azure): set the source for the AKS module to NEDSS-Infrastructure

### DIFF
--- a/terraform/azure/modules/2-nbs7/aks/aks-module.tf
+++ b/terraform/azure/modules/2-nbs7/aks/aks-module.tf
@@ -13,8 +13,7 @@ resource "azurerm_user_assigned_identity" "aks" {
 }
 
 module "aks" {
-  source  = "Azure/aks/azurerm"
-  version = "11.5.0"
+  source  = "git::https://github.com/CDCgov/NEDSS-Infrastructure.git//terraform/azure/modules/vendor/Azure/terraform-azurerm-aks/?depth=1&ref=v1.2.48"
 
   resource_group_name         = data.azurerm_resource_group.rg.name
   cluster_name                = var.k8_cluster_name

--- a/terraform/azure/modules/2-nbs7/aks/providers.tf
+++ b/terraform/azure/modules/2-nbs7/aks/providers.tf
@@ -12,11 +12,11 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~>3.0"
+      version = ">=3.9.0, <4.0.0"
     }
     time = {
       source  = "hashicorp/time"
-      version = "0.9.1"
+      version = ">=0.14.0"
     }
   }
 }


### PR DESCRIPTION
Switches the source to `NEDSS-Infrastructure.git//terraform/azure/modules/vendor/Azure/terraform-azurerm-aks/?depth=1&ref=v1.2.48`