### PR TITLE
feat(aws): update default msk kafka version to 3.9.x

### DIFF
--- a/terraform/aws/modules/2-nbs7/msk/variables.tf
+++ b/terraform/aws/modules/2-nbs7/msk/variables.tf
@@ -70,5 +70,5 @@ variable "cidr_blocks" {
 variable "kafka_version" {
   description = "Version of Kafka to be deployed in cluster"
   type        = string
-  default     = "3.9.0"
+  default     = "3.9.x"
 }

--- a/terraform/aws/modules/2-nbs7/msk/variables.tf
+++ b/terraform/aws/modules/2-nbs7/msk/variables.tf
@@ -70,5 +70,5 @@ variable "cidr_blocks" {
 variable "kafka_version" {
   description = "Version of Kafka to be deployed in cluster"
   type        = string
-  default     = "3.6.0"
+  default     = "3.9.0"
 }


### PR DESCRIPTION
This PR updates the default version of Kafka on MSK to 3.9 