### PR TITLE
feat(aws):make cert-manager optional

### DIFF
--- a/terraform/aws/modules/2-nbs7/eks-nbs/helm.tf
+++ b/terraform/aws/modules/2-nbs7/eks-nbs/helm.tf
@@ -121,7 +121,7 @@ resource "helm_release" "cert_manager" {
     # Set values for OIDC
     {
       name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
-      value = module.cert_manager_cni_irsa_role[count.index].arn
+      value = module.cert_manager_cni_irsa_role.arn
     },
     {
       name  = "securityContext.fsGroup"

--- a/terraform/aws/modules/2-nbs7/eks-nbs/helm.tf
+++ b/terraform/aws/modules/2-nbs7/eks-nbs/helm.tf
@@ -102,6 +102,7 @@ resource "helm_release" "argocd" {
 
 # create cert manager release
 resource "helm_release" "cert_manager" {
+  count            = var.enable_cert_manager ? 1 : 0
   provider         = helm
   name             = "cert-manager"
   namespace        = "cert-manager"
@@ -120,7 +121,7 @@ resource "helm_release" "cert_manager" {
     # Set values for OIDC
     {
       name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
-      value = module.cert_manager_cni_irsa_role.arn
+      value = module.cert_manager_cni_irsa_role[count.index].arn
     },
     {
       name  = "securityContext.fsGroup"

--- a/terraform/aws/modules/2-nbs7/eks-nbs/irsa.tf
+++ b/terraform/aws/modules/2-nbs7/eks-nbs/irsa.tf
@@ -20,9 +20,9 @@ module "efs_cni_irsa_role" {
 module "cert_manager_cni_irsa_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version = ">=6.2.3, <7.0.0"
-
+  
+  create                      = var.enable_cert_manager
   name                       = "${local.eks_name}-cert-manager-cni" #defined in main.tf
-  create                     = true
   attach_cert_manager_policy = true
 
   oidc_providers = {

--- a/terraform/aws/modules/2-nbs7/eks-nbs/irsa.tf
+++ b/terraform/aws/modules/2-nbs7/eks-nbs/irsa.tf
@@ -21,8 +21,8 @@ module "cert_manager_cni_irsa_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version = ">=6.2.3, <7.0.0"
 
-  create                     = var.enable_cert_manager
   name                       = "${local.eks_name}-cert-manager-cni" #defined in main.tf
+  create                     = var.enable_cert_manager
   attach_cert_manager_policy = true
 
   oidc_providers = {

--- a/terraform/aws/modules/2-nbs7/eks-nbs/irsa.tf
+++ b/terraform/aws/modules/2-nbs7/eks-nbs/irsa.tf
@@ -20,8 +20,8 @@ module "efs_cni_irsa_role" {
 module "cert_manager_cni_irsa_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
   version = ">=6.2.3, <7.0.0"
-  
-  create                      = var.enable_cert_manager
+
+  create                     = var.enable_cert_manager
   name                       = "${local.eks_name}-cert-manager-cni" #defined in main.tf
   attach_cert_manager_policy = true
 

--- a/terraform/aws/modules/2-nbs7/eks-nbs/variables.tf
+++ b/terraform/aws/modules/2-nbs7/eks-nbs/variables.tf
@@ -165,8 +165,8 @@ variable "kms_key_enable_default_policy" {
 
 variable "enable_cert_manager" {
   description = "Create cert-manager helm release and associated IAM role"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "cert_manager_hosted_zone_arns" {

--- a/terraform/aws/modules/2-nbs7/eks-nbs/variables.tf
+++ b/terraform/aws/modules/2-nbs7/eks-nbs/variables.tf
@@ -163,6 +163,12 @@ variable "kms_key_enable_default_policy" {
   default     = false
 }
 
+variable "enable_cert_manager" {
+  description = "Create cert-manager helm release and associated IAM role"
+  type = bool
+  default = true
+}
+
 variable "cert_manager_hosted_zone_arns" {
   description = "ARNs for Route 53 hosted zones that Cert Manager can access"
   type        = list(string)

--- a/terraform/azure/modules/2-nbs7/aks/aks-module.tf
+++ b/terraform/azure/modules/2-nbs7/aks/aks-module.tf
@@ -13,7 +13,7 @@ resource "azurerm_user_assigned_identity" "aks" {
 }
 
 module "aks" {
-  source  = "git::https://github.com/CDCgov/NEDSS-Infrastructure.git//terraform/azure/modules/vendor/Azure/terraform-azurerm-aks/?depth=1&ref=v1.2.48"
+  source = "git::https://github.com/CDCgov/NEDSS-Infrastructure.git//terraform/azure/modules/vendor/Azure/terraform-azurerm-aks/?depth=1&ref=v1.2.48"
 
   resource_group_name         = data.azurerm_resource_group.rg.name
   cluster_name                = var.k8_cluster_name


### PR DESCRIPTION
This PR makes cert-manager helm release and the associated irsa role optional for the eks-nbs module