### PR TITLE
feat(azure): dns record submodules

### DIFF
--- a/terraform/azure/modules/0-landing-zone/private-dns-zone/README.md
+++ b/terraform/azure/modules/0-landing-zone/private-dns-zone/README.md
@@ -14,7 +14,9 @@
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_dns_records"></a> [dns\_records](#module\_dns\_records) | ./modules/dns-record | n/a |
 
 ## Resources
 
@@ -28,6 +30,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_dns_records"></a> [dns\_records](#input\_dns\_records) | A map of DNS records to create | <pre>map(object({<br/>    record_name  = string<br/>    record_type  = string<br/>    ttl          = optional(number, 300)<br/>    records      = optional(list(string))<br/>    cname_record = optional(string)<br/>  }))</pre> | `{}` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether to have Terraform provision the resources from this module in your Azure subscription | `bool` | `true` | no |
 | <a name="input_private_dns_zone_name"></a> [private\_dns\_zone\_name](#input\_private\_dns\_zone\_name) | Name for the private dns zone | `string` | `""` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group | `string` | `""` | no |

--- a/terraform/azure/modules/0-landing-zone/private-dns-zone/main.tf
+++ b/terraform/azure/modules/0-landing-zone/private-dns-zone/main.tf
@@ -12,3 +12,17 @@ resource "azurerm_private_dns_zone_virtual_network_link" "private" {
   virtual_network_id    = var.vnet_id
   registration_enabled  = true
 }
+
+module "dns_records" {
+  source   = "./modules/dns-record" # Update with your actual module path
+  for_each = var.dns_records
+
+  resource_group_name = var.resource_group_name
+  zone_name           = azurerm_private_dns_zone.private.name
+
+  record_name  = each.value.record_name
+  record_type  = each.value.record_type
+  ttl          = each.value.ttl
+  records      = each.value.records
+  cname_record = each.value.cname_record
+}

--- a/terraform/azure/modules/0-landing-zone/private-dns-zone/modules/dns-record/README.md
+++ b/terraform/azure/modules/0-landing-zone/private-dns-zone/modules/dns-record/README.md
@@ -1,0 +1,38 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [azurerm_private_dns_a_record.a](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
+| [azurerm_private_dns_cname_record.cname](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_cname_record) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_cname_record"></a> [cname\_record](#input\_cname\_record) | The target domain name. Required if record\_type is 'CNAME'. | `string` | `null` | no |
+| <a name="input_record_name"></a> [record\_name](#input\_record\_name) | The name of the private DNS record. | `string` | n/a | yes |
+| <a name="input_record_type"></a> [record\_type](#input\_record\_type) | The type of record to create. Must be either 'A' or 'CNAME'. | `string` | n/a | yes |
+| <a name="input_records"></a> [records](#input\_records) | A list of IPv4 addresses. Required if record\_type is 'A'. | `list(string)` | `null` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group where the Private DNS zone exists. | `string` | n/a | yes |
+| <a name="input_ttl"></a> [ttl](#input\_ttl) | The Time To Live (TTL) of the DNS record in seconds. | `number` | `3600` | no |
+| <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | The name of the private DNS zone (e.g., 'privatelink.database.windows.net'). | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/terraform/azure/modules/0-landing-zone/private-dns-zone/modules/dns-record/main.tf
+++ b/terraform/azure/modules/0-landing-zone/private-dns-zone/modules/dns-record/main.tf
@@ -1,0 +1,17 @@
+resource "azurerm_private_dns_a_record" "a" {
+  count               = upper(var.record_type) == "A" ? 1 : 0
+  name                = var.record_name
+  zone_name           = var.zone_name
+  resource_group_name = var.resource_group_name
+  ttl                 = var.ttl
+  records             = var.records
+}
+
+resource "azurerm_private_dns_cname_record" "cname" {
+  count               = upper(var.record_type) == "CNAME" ? 1 : 0
+  name                = var.record_name
+  zone_name           = var.zone_name
+  resource_group_name = var.resource_group_name
+  ttl                 = var.ttl
+  record              = var.cname_record
+}

--- a/terraform/azure/modules/0-landing-zone/private-dns-zone/modules/dns-record/variables.tf
+++ b/terraform/azure/modules/0-landing-zone/private-dns-zone/modules/dns-record/variables.tf
@@ -1,0 +1,41 @@
+variable "resource_group_name" {
+  description = "The name of the resource group where the Private DNS zone exists."
+  type        = string
+}
+
+variable "zone_name" {
+  description = "The name of the private DNS zone (e.g., 'privatelink.database.windows.net')."
+  type        = string
+}
+
+variable "record_name" {
+  description = "The name of the private DNS record."
+  type        = string
+}
+
+variable "record_type" {
+  description = "The type of record to create. Must be either 'A' or 'CNAME'."
+  type        = string
+  validation {
+    condition     = contains(["A", "CNAME"], upper(var.record_type))
+    error_message = "The record_type must be either 'A' or 'CNAME'."
+  }
+}
+
+variable "ttl" {
+  description = "The Time To Live (TTL) of the DNS record in seconds."
+  type        = number
+  default     = 3600
+}
+
+variable "records" {
+  description = "A list of IPv4 addresses. Required if record_type is 'A'."
+  type        = list(string)
+  default     = null
+}
+
+variable "cname_record" {
+  description = "The target domain name. Required if record_type is 'CNAME'."
+  type        = string
+  default     = null
+}

--- a/terraform/azure/modules/0-landing-zone/private-dns-zone/variables.tf
+++ b/terraform/azure/modules/0-landing-zone/private-dns-zone/variables.tf
@@ -27,3 +27,15 @@ variable "vnet_name" {
   type        = string
   description = "vnet name"
 }
+
+variable "dns_records" {
+  description = "A map of DNS records to create"
+  type = map(object({
+    record_name  = string
+    record_type  = string
+    ttl          = optional(number, 300)
+    records      = optional(list(string))
+    cname_record = optional(string)
+  }))
+  default = {}
+}

--- a/terraform/azure/modules/0-landing-zone/public-dns-zone/main.tf
+++ b/terraform/azure/modules/0-landing-zone/public-dns-zone/main.tf
@@ -3,3 +3,17 @@ resource "azurerm_dns_zone" "public" {
   name                = var.public_domain_name
   resource_group_name = var.resource_group_name
 }
+
+module "dns_records" {
+  source   = "./modules/dns-record" 
+  for_each = var.dns_records
+
+  resource_group_name = var.resource_group_name
+  zone_name           = azurerm_private_dns_zone.private.name
+
+  record_name  = each.value.record_name
+  record_type  = each.value.record_type
+  ttl          = try(each.value.ttl, null)
+  records      = try(each.value.records, null)
+  cname_record = try(each.value.cname_record, null)
+}

--- a/terraform/azure/modules/0-landing-zone/public-dns-zone/modules/dns-record/README.md
+++ b/terraform/azure/modules/0-landing-zone/public-dns-zone/modules/dns-record/README.md
@@ -1,0 +1,38 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [azurerm_dns_a_record.a](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_a_record) | resource |
+| [azurerm_dns_cname_record.cname](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_cname_record) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_cname_record"></a> [cname\_record](#input\_cname\_record) | The target domain name. Required if record\_type is 'CNAME'. | `string` | `null` | no |
+| <a name="input_record_name"></a> [record\_name](#input\_record\_name) | The name of the DNS record (e.g., 'www' or '@' for root). | `string` | n/a | yes |
+| <a name="input_record_type"></a> [record\_type](#input\_record\_type) | The type of record to create. Must be either 'A' or 'CNAME'. | `string` | n/a | yes |
+| <a name="input_records"></a> [records](#input\_records) | A list of IPv4 addresses. Required if record\_type is 'A'. | `list(string)` | `null` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group where the DNS zone exists. | `string` | n/a | yes |
+| <a name="input_ttl"></a> [ttl](#input\_ttl) | The Time To Live (TTL) of the DNS record in seconds. | `number` | `3600` | no |
+| <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | The name of the public DNS zone. | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/terraform/azure/modules/0-landing-zone/public-dns-zone/modules/dns-record/main.tf
+++ b/terraform/azure/modules/0-landing-zone/public-dns-zone/modules/dns-record/main.tf
@@ -1,0 +1,17 @@
+resource "azurerm_dns_a_record" "a" {
+  count               = upper(var.record_type) == "A" ? 1 : 0
+  name                = var.record_name
+  zone_name           = var.zone_name
+  resource_group_name = var.resource_group_name
+  ttl                 = var.ttl
+  records             = var.records
+}
+
+resource "azurerm_dns_cname_record" "cname" {
+  count               = upper(var.record_type) == "CNAME" ? 1 : 0
+  name                = var.record_name
+  zone_name           = var.zone_name
+  resource_group_name = var.resource_group_name
+  ttl                 = var.ttl
+  record              = var.cname_record
+}

--- a/terraform/azure/modules/0-landing-zone/public-dns-zone/modules/dns-record/variables.tf
+++ b/terraform/azure/modules/0-landing-zone/public-dns-zone/modules/dns-record/variables.tf
@@ -1,0 +1,41 @@
+variable "resource_group_name" {
+  description = "The name of the resource group where the DNS zone exists."
+  type        = string
+}
+
+variable "zone_name" {
+  description = "The name of the public DNS zone."
+  type        = string
+}
+
+variable "record_name" {
+  description = "The name of the DNS record (e.g., 'www' or '@' for root)."
+  type        = string
+}
+
+variable "record_type" {
+  description = "The type of record to create. Must be either 'A' or 'CNAME'."
+  type        = string
+  validation {
+    condition     = contains(["A", "CNAME"], upper(var.record_type))
+    error_message = "The record_type must be either 'A' or 'CNAME'."
+  }
+}
+
+variable "ttl" {
+  description = "The Time To Live (TTL) of the DNS record in seconds."
+  type        = number
+  default     = 3600
+}
+
+variable "records" {
+  description = "A list of IPv4 addresses. Required if record_type is 'A'."
+  type        = list(string)
+  default     = null
+}
+
+variable "cname_record" {
+  description = "The target domain name. Required if record_type is 'CNAME'."
+  type        = string
+  default     = null
+}

--- a/terraform/azure/modules/0-landing-zone/public-dns-zone/variables.tf
+++ b/terraform/azure/modules/0-landing-zone/public-dns-zone/variables.tf
@@ -23,3 +23,15 @@ variable "public_domain_name" {
     error_message = "public_domain_name must have a value if module is enabled"
   }
 }
+
+variable "dns_records" {
+  description = "A map of DNS records to create"
+  type = map(object({
+    record_name  = string
+    record_type  = string
+    ttl          = optional(number, 300)
+    records      = optional(list(string))
+    cname_record = optional(string)
+  }))
+  default = {}
+}


### PR DESCRIPTION
Adds submodules to the private-dns-zone and public-dns-zone modules for creating individual dns records.  Can be used individually or as part of the *-dns-zone module.