### PR TITLE
add Cluster Autoscaler IRSA role and policy

### DIFF
--- a/terraform/aws/modules/2-nbs7/eks-nbs/irsa.tf
+++ b/terraform/aws/modules/2-nbs7/eks-nbs/irsa.tf
@@ -130,3 +130,70 @@ resource "aws_iam_policy" "datacompare_irsa_policy" {
     ]
   })
 }
+
+# ──────────────────────────────────────────────────────────
+# Cluster Autoscaler IRSA
+# ──────────────────────────────────────────────────────────
+
+module "cluster_autoscaler_irsa_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = ">=6.2.3, <7.0.0"
+
+  name   = "${local.eks_name}-cluster-autoscaler"
+  create = var.create_cluster_autoscaler_irsa
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:cluster-autoscaler-aws-cluster-autoscaler"]
+    }
+  }
+
+  policies = {
+    policy = try(aws_iam_policy.cluster_autoscaler_irsa_policy[0].arn, null)
+  }
+}
+
+resource "aws_iam_policy" "cluster_autoscaler_irsa_policy" {
+  count       = var.create_cluster_autoscaler_irsa ? 1 : 0
+  name        = "${local.eks_name}-cluster-autoscaler-policy"
+  description = "Cluster Autoscaler permissions for EKS node group scaling"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ClusterAutoscalerDescribe"
+        Effect = "Allow"
+        Action = [
+          "autoscaling:DescribeAutoScalingGroups",
+          "autoscaling:DescribeAutoScalingInstances",
+          "autoscaling:DescribeLaunchConfigurations",
+          "autoscaling:DescribeScalingActivities",
+          "autoscaling:DescribeTags",
+          "ec2:DescribeImages",
+          "ec2:DescribeInstanceTypes",
+          "ec2:DescribeLaunchTemplateVersions",
+          "ec2:GetInstanceTypesFromInstanceRequirements",
+          "eks:DescribeNodegroup"
+        ]
+        Resource = ["*"]
+      },
+      {
+        Sid    = "ClusterAutoscalerScale"
+        Effect = "Allow"
+        Action = [
+          "autoscaling:SetDesiredCapacity",
+          "autoscaling:TerminateInstanceInAutoScalingGroup"
+        ]
+        Resource = ["*"]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/k8s.io/cluster-autoscaler/enabled"                  = "true"
+            "aws:ResourceTag/k8s.io/cluster-autoscaler/${var.cluster_autoscaler_cluster_name}" = "owned"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/terraform/aws/modules/2-nbs7/eks-nbs/outputs.tf
+++ b/terraform/aws/modules/2-nbs7/eks-nbs/outputs.tf
@@ -46,5 +46,5 @@ output "otel_collector_role_arn" {
 
 output "cluster_autoscaler_irsa_role_arn" {
   description = "ARN of the Cluster Autoscaler IRSA role"
-  value       = var.create_cluster_autoscaler_irsa ? module.cluster_autoscaler_irsa_role.iam_role_arn : null
+  value       = var.create_cluster_autoscaler_irsa ? module.cluster_autoscaler_irsa_role.arn : null
 }

--- a/terraform/aws/modules/2-nbs7/eks-nbs/outputs.tf
+++ b/terraform/aws/modules/2-nbs7/eks-nbs/outputs.tf
@@ -43,3 +43,8 @@ output "otel_collector_role_arn" {
   description = "OTEL Collector IRSA role ARN — pass to helm install via --set serviceAccount.annotations"
   value       = var.create_otel_collector_irsa ? module.otel_collector_irsa_role.arn : null
 }
+
+output "cluster_autoscaler_irsa_role_arn" {
+  description = "ARN of the Cluster Autoscaler IRSA role"
+  value       = var.create_cluster_autoscaler_irsa ? module.cluster_autoscaler_irsa_role.iam_role_arn : null
+}

--- a/terraform/aws/modules/2-nbs7/eks-nbs/variables.tf
+++ b/terraform/aws/modules/2-nbs7/eks-nbs/variables.tf
@@ -254,3 +254,15 @@ variable "datacompare_s3_bucket_keyname_prefix" {
     error_message = "The datacompare_s3_bucket_keyname_prefix variable must be an empty string or end with a forward slash (/). Example: 'myFolder/' or \"\"."
   }
 }
+
+variable "create_cluster_autoscaler_irsa" {
+  description = "Whether to create the Cluster Autoscaler IRSA role and policy"
+  type        = bool
+  default     = false
+}
+
+variable "cluster_autoscaler_cluster_name" {
+  description = "EKS cluster name for Cluster Autoscaler IAM policy tag-based scoping"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary
Add IRSA (IAM Role for Service Accounts) support for the Cluster Autoscaler in the eks-nbs module. The autoscaler Helm chart was previously deployed on dev71 without IAM permissions — the ServiceAccount had no role annotation, so it couldn't call AWS APIs to scale nodes.


## Changes

- irsa.tf — New `cluster_autoscaler_irsa_role` module and `cluster_autoscaler_irsa_policy `IAM policy with tag-scoped autoscaling permissions
- variables.tf — New` create_cluster_autoscaler_irsa` (bool) and `cluster_autoscaler_cluster_name` (string) variables, both defaulting to off so existing environments are unaffected
- outputs.tf — New `cluster_autoscaler_irsa_role_arn` output

## IAM Policy Details

- Describe actions (`DescribeAutoScalingGroups, DescribeTags, DescribeInstanceTypes, eks:DescribeNodegroup`, etc.) use `Resource: "*"` as these APIs don't support resource-level restrictions
- Scale actions (`SetDesiredCapacity, TerminateInstanceInAutoScalingGroup`) are scoped via k`8s.io/cluster-autoscaler` tag-based IAM conditions per upstream [Cluster Autoscaler best practices](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md)
- SonarCloud` Resource: "*"` findings reviewed and safe to dismiss

## Validation

- Tested end-to-end on nbs7-dev2-eks
- Applied Terraform — created IRSA role and policy
- Deployed Cluster Autoscaler via `helm install` with `--set` for the SA annotation
- Confirmed SA annotated with role ARN
- Autoscaler logs show successful ASG discovery, no `AccessDenied` errors, scale-down evaluation running on all nodes
- Chart version: `cluster-autoscaler-9.58.0`