### PR TITLE
fix(azure): make registration_enabled optional

### DIFF
--- a/terraform/azure/modules/0-landing-zone/private-dns-zone/main.tf
+++ b/terraform/azure/modules/0-landing-zone/private-dns-zone/main.tf
@@ -10,7 +10,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "private" {
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.private[count.index].name
   virtual_network_id    = var.vnet_id
-  registration_enabled  = true
+  registration_enabled  = var.registration_enabled
 }
 
 module "dns_records" {
@@ -18,7 +18,7 @@ module "dns_records" {
   for_each = var.dns_records
 
   resource_group_name = var.resource_group_name
-  zone_name           = azurerm_private_dns_zone.private.name
+  zone_name           = azurerm_private_dns_zone.private[0].name
 
   record_name  = each.value.record_name
   record_type  = each.value.record_type

--- a/terraform/azure/modules/0-landing-zone/private-dns-zone/variables.tf
+++ b/terraform/azure/modules/0-landing-zone/private-dns-zone/variables.tf
@@ -39,3 +39,9 @@ variable "dns_records" {
   }))
   default = {}
 }
+
+variable "registration_enabled" {
+  description = "Whether auto registration is enabled"
+  type        = bool
+  default     = false
+}

--- a/terraform/azure/modules/0-landing-zone/public-dns-zone/main.tf
+++ b/terraform/azure/modules/0-landing-zone/public-dns-zone/main.tf
@@ -9,7 +9,7 @@ module "dns_records" {
   for_each = var.dns_records
 
   resource_group_name = var.resource_group_name
-  zone_name           = azurerm_private_dns_zone.private.name
+  zone_name           = azurerm_private_dns_zone.private[0].name
 
   record_name  = each.value.record_name
   record_type  = each.value.record_type


### PR DESCRIPTION
Fixes an issue when multiple private dns zones are linked to a single vnet