### PR TITLE
feat(agw-public): allow multiple hostnames on the public listeners

### DIFF
--- a/terraform/azure/modules/2-nbs7/agw-public/main.tf
+++ b/terraform/azure/modules/2-nbs7/agw-public/main.tf
@@ -169,7 +169,7 @@ resource "azurerm_application_gateway" "agw_public" {
     name                = local.probe_name_public
     protocol            = "Https"
     path                = "/nbs/login"
-    host                = var.agw_backend_host
+    host                = var.agw_app_backend_host
     interval            = 30
     timeout             = 30
     unhealthy_threshold = 3
@@ -195,7 +195,10 @@ resource "azurerm_application_gateway" "agw_public" {
     frontend_port_name             = local.frontend_port_name
     protocol                       = "Https"
     ssl_certificate_name           = local.cert_name_public
-    host_name                      = var.agw_public_hostname
+    host_names = [
+      var.agw_app_public_hostname,
+      var.agw_data_public_hostname,
+    ]
   }
 
   http_listener {
@@ -203,7 +206,10 @@ resource "azurerm_application_gateway" "agw_public" {
     frontend_ip_configuration_name = local.frontend_ip_configuration_name_public
     frontend_port_name             = local.frontend_port_name_http
     protocol                       = "Http"
-    host_name                      = var.agw_public_hostname
+    host_names = [
+      var.agw_app_public_hostname,
+      var.agw_data_public_hostname,
+    ]
   }
 
   redirect_configuration {

--- a/terraform/azure/modules/2-nbs7/agw-public/variables.tf
+++ b/terraform/azure/modules/2-nbs7/agw-public/variables.tf
@@ -65,7 +65,15 @@ variable "agw_key_vault_cert_name_private" {
   default     = null
 }
 
-variable "agw_backend_host" {
+variable "agw_app_backend_host" {
+  description = <<-EOT
+  The target host header or FQDN expected by the Traefik ingress 
+  controller for routing.
+EOT
+  type        = string
+}
+
+variable "agw_data_backend_host" {
   description = <<-EOT
   The target host header or FQDN expected by the Traefik ingress 
   controller for routing.
@@ -145,7 +153,7 @@ variable "enable_dual_gateway" {
   default     = true
 }
 
-variable "agw_public_hostname" {
+variable "agw_app_public_hostname" {
   description = <<EOT
   The public FQDN mapped to the Application Gateway public listener.
   EOT
@@ -153,10 +161,26 @@ variable "agw_public_hostname" {
 
   validation {
     condition = can(
-      regex("^[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", var.agw_public_hostname)
+      regex("^[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", var.agw_app_public_hostname)
     )
     error_message = <<EOT
-    The agw_public_hostname must be a valid fully qualified domain name (FQDN)
+    The agw_app_public_hostname must be a valid fully qualified domain name (FQDN)
+    EOT
+  }
+}
+
+variable "agw_data_public_hostname" {
+  description = <<EOT
+  The public FQDN mapped to the Application Gateway public listener.
+  EOT
+  type        = string
+
+  validation {
+    condition = can(
+      regex("^[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", var.agw_data_public_hostname)
+    )
+    error_message = <<EOT
+    The agw_data_public_hostname must be a valid fully qualified domain name (FQDN)
     EOT
   }
 }


### PR DESCRIPTION
This PR allows multiple hostnames (`app-*` and `data-*`) to be added to the public listeners for the public application gateway.