### PR TITLE
fix(nbs_eks): deprecate cluster_version

### DIFF
--- a/terraform/aws/modules/2-nbs7/eks-nbs/locals.tf
+++ b/terraform/aws/modules/2-nbs7/eks-nbs/locals.tf
@@ -3,6 +3,9 @@ locals {
   eks_iam_role_name   = var.name != "" ? "${var.name}-role" : "${var.resource_prefix}-eks-role"
   eks_node_group_name = var.name != "" ? "eks-nbs-main" : "${var.resource_prefix}-node-group-main"
 
+  kubernetes_version_control_plane = var.cluster_version != null ? var.cluster_version : var.kubernetes_version_control_plane
+  kubernetes_version_node_group    = var.cluster_version != null ? var.cluster_version : var.kubernetes_version_node_group
+
   # Merge old single-value variables with new list variables for backward compatibility
   admin_roles = length(var.admin_role_arns) > 0 ? var.admin_role_arns : [var.aws_role_arn]
 

--- a/terraform/aws/modules/2-nbs7/eks-nbs/main.tf
+++ b/terraform/aws/modules/2-nbs7/eks-nbs/main.tf
@@ -7,7 +7,7 @@ module "eks" {
 
   # Set cluster info
   name                   = local.eks_name
-  kubernetes_version     = var.kubernetes_version_control_plane
+  kubernetes_version     = local.kubernetes_version_control_plane
   endpoint_public_access = var.allow_endpoint_public_access
 
   # Set VPC/Subnets
@@ -39,7 +39,7 @@ module "eks" {
       use_latest_ami_release_version = false
       ami_release_version            = var.ami_release_version
 
-      kubernetes_version = var.kubernetes_version_node_group
+      kubernetes_version = local.kubernetes_version_node_group
 
       block_device_mappings = {
         xvda = {

--- a/terraform/aws/modules/2-nbs7/eks-nbs/variables.tf
+++ b/terraform/aws/modules/2-nbs7/eks-nbs/variables.tf
@@ -51,8 +51,15 @@ variable "readonly_role_arns" {
 
 variable "kubernetes_version_control_plane" {
   description = "Desired Kubernetes version for control plane in EKS cluster"
+  type        = string
   default     = "1.35"
   nullable    = false
+}
+
+variable "cluster_version" {
+  description = "(DEPRECATED) Version of the AWS EKS cluster to provision"
+  default     = null
+  deprecated  = "Use `kubernetes_version_control_plane` and `kubernetes_version_node_group` to set kubernetes versions"
 }
 
 variable "desired_nodes_count" {
@@ -75,6 +82,7 @@ variable "min_nodes_count" {
 
 variable "kubernetes_version_node_group" {
   description = "Kubernetes version for node group in EKS cluster"
+  type        = string
   default     = "1.35"
   nullable    = false
 }


### PR DESCRIPTION
Deprecates `cluster_version` using the new `deprecated` variable argument to ensure that STLTs using the current terraform code have a smoother upgrade process.