### PR TITLE
fix(aws): rename sample layers to align with the removal of nbs6

### DIFF
--- a/terraform/aws/samples/0-landing-zone/README.md
+++ b/terraform/aws/samples/0-landing-zone/README.md
@@ -11,7 +11,7 @@ This module:
 
 Typical usage:
 
-- **0-landing-zone \(this module)** → 1-nbs6 → 2-nbs7 → 3-applications
+- **0-landing-zone \(this module)** → 1-nbs7 → 2-applications
 - Environment-specific deployments (dev / stage / prod)
 
 ## 💻 System Prerequisites

--- a/terraform/aws/samples/1-nbs7/README.md
+++ b/terraform/aws/samples/1-nbs7/README.md
@@ -1,4 +1,4 @@
-# Terraform Module: 2-nbs7
+# Terraform Module: 1-nbs7
 
 This Terraform module layer provisions infrastructure required to run nbs7 and **expects certain upstream infrastructure
 to already exist** (VPCs, subnets, IAM roles etc.). This README explains **how those dependencies are referenced**.
@@ -12,7 +12,7 @@ This module:
 
 Typical usage:
 
-- 0-landing-zone → 1-nbs6 → **2-nbs7 \(this module)** → 3-applications
+- 0-landing-zone → **1-nbs7 \(this module)** → 2-applications
 - Environment-specific deployments (dev / stage / prod)
 
 ## 💻 System Prerequisites
@@ -27,8 +27,8 @@ Typical usage:
 <details>
 <summary><strong> Networking Dependencies</strong></summary>
 
-Networking including VPCs and public hosted zones **must already exist** and are referenced as described below. While 1-nbs6 components are expected to exist
-in order for NBS7 microservices to be deployed successfully, the 2-nbs7 infrastructure **does not** directly depend on functional NBS6 services. Exceptions to
+Networking including VPCs and public hosted zones **must already exist** and are referenced as described below. While nbs6 components are expected to exist
+in order for NBS7 microservices to be deployed successfully, the 1-nbs7 infrastructure **does not** directly depend on functional NBS6 services. Exceptions to
 this include modifying security groups to allow operations involving the database.
 
 | Resource    | Description                                                                                     | How It’s Referenced     |
@@ -126,7 +126,7 @@ this include modifying security groups to allow operations involving the databas
 ```bash
 # Download appropriate GitHub release from https://github.com/CDCgov/NEDSS-Infrastructure/releases
 unzip <nbs-infrastructure-v<VERSION>.zip # replace version with your downloaded version
-cd terraform/aws/samples/2-nbs7
+cd terraform/aws/samples/1-nbs7
 terraform init
 terraform plan
 terraform apply

--- a/terraform/aws/samples/1-nbs7/efs.tf
+++ b/terraform/aws/samples/1-nbs7/efs.tf
@@ -1,5 +1,5 @@
 module "efs" {
-  source          = "../../modules/2-nbs7/efs"
+  source          = "../../modules/1-nbs7/efs"
   resource_prefix = var.resource_prefix
   vpc_id          = data.aws_vpc.nbs7.id
   vpc_cidrs = var.efs_subnet_cidrs == null ? [

--- a/terraform/aws/samples/1-nbs7/eks.tf
+++ b/terraform/aws/samples/1-nbs7/eks.tf
@@ -1,5 +1,5 @@
 module "eks_nbs" {
-  source                       = "../../modules/2-nbs7/eks-nbs"
+  source                       = "../../modules/1-nbs7/eks-nbs"
   subnets                      = var.eks_subnets != null ? var.eks_subnets : data.aws_subnets.nbs7.ids
   vpc_id                       = data.aws_vpc.nbs7.id
   aws_role_arn                 = var.aws_role_arn

--- a/terraform/aws/samples/1-nbs7/kms.tf
+++ b/terraform/aws/samples/1-nbs7/kms.tf
@@ -1,5 +1,5 @@
 module "kms" {
-  source      = "../../modules/2-nbs7/kms"
+  source      = "../../modules/1-nbs7/kms"
   aliases     = ["efs/${var.resource_prefix}-key"]
   description = "KMS key used for EFS: ${var.resource_prefix}-efs"
 }

--- a/terraform/aws/samples/1-nbs7/msk.tf
+++ b/terraform/aws/samples/1-nbs7/msk.tf
@@ -1,5 +1,5 @@
 module "msk" {
-  source              = "../../modules/2-nbs7/msk"
+  source              = "../../modules/1-nbs7/msk"
   msk_subnet_ids      = var.msk_subnets == null ? (var.msk_environment == "production" ? [data.aws_subnets.nbs7.ids[0], data.aws_subnets.nbs7.ids[1], data.aws_subnets.nbs7.ids[2]] : [data.aws_subnets.nbs7.ids[0], data.aws_subnets.nbs7.ids[1]]) : var.msk_subnets
   vpc_id              = data.aws_vpc.nbs7.id
   msk_ebs_volume_size = var.msk_ebs_volume_size

--- a/terraform/aws/samples/1-nbs7/s3_buckets.tf
+++ b/terraform/aws/samples/1-nbs7/s3_buckets.tf
@@ -1,6 +1,6 @@
 module "s3_datacompare" {
   count                                  = var.create_datacompare_resources ? 1 : 0
-  source                                 = "../../modules/2-nbs7/s3-bucket"
+  source                                 = "../../modules/1-nbs7/s3-bucket"
   tags                                   = var.tags
   bucket_prefix                          = "${var.resource_prefix}-"
   enable_default_bucket_lifecycle_policy = "Enabled"
@@ -8,7 +8,7 @@ module "s3_datacompare" {
 
 module "s3_otel_logs" {
   count                                  = var.create_otel_collector_resources ? 1 : 0
-  source                                 = "../../modules/2-nbs7/s3-bucket"
+  source                                 = "../../modules/1-nbs7/s3-bucket"
   tags                                   = var.tags
   bucket_prefix                          = "${var.resource_prefix}-otel-logs-"
   enable_default_bucket_lifecycle_policy = "Enabled"

--- a/terraform/aws/samples/1-nbs7/terraform.tf
+++ b/terraform/aws/samples/1-nbs7/terraform.tf
@@ -19,7 +19,7 @@ terraform {
   backend "s3" {
     encrypt = true
     bucket  = "<EXAMPLE_AWS_S3_BUCKET_NAME>"                   # e.g. "cdc-nbs-terraform"
-    key     = "<EXAMPLE_ENVIRONMENT>/2-nbs7/terraform.tfstate" # e.g. production/2-nbs7/terraform.tfstate
+    key     = "<EXAMPLE_ENVIRONMENT>/1-nbs7/terraform.tfstate" # e.g. production/1-nbs7/terraform.tfstate
     region  = "<EXAMPLE_AWS_REGION>"                           # e.g. us-east-1
   }
 }

--- a/terraform/aws/samples/1-nbs7/terraform.tfvars
+++ b/terraform/aws/samples/1-nbs7/terraform.tfvars
@@ -1,4 +1,4 @@
-# 2-nbs7 parameter inputs
+# 1-nbs7 parameter inputs
 #
 # Search and replace variable values beginning with "EXAMPLE_" to appropriate values
 

--- a/terraform/aws/samples/1-nbs7/vpc-endpoints.tf
+++ b/terraform/aws/samples/1-nbs7/vpc-endpoints.tf
@@ -1,5 +1,5 @@
 module "vpc-endpoints" {
-  source = "../../modules/2-nbs7/vpc-endpoints-nbs"
+  source = "../../modules/1-nbs7/vpc-endpoints-nbs"
 
   create_prometheus_vpc_endpoint = var.create_prometheus_vpc_endpoint
   create_grafana_vpc_endpoint    = var.create_grafana_vpc_endpoint

--- a/terraform/aws/samples/2-applications/README.md
+++ b/terraform/aws/samples/2-applications/README.md
@@ -1,4 +1,4 @@
-# Terraform Module: 3-applications
+# Terraform Module: 2-applications
 
 This Terraform module layer provisions applications being deployed to Kubernetes and **expects certain upstream infrastructure
 to already exist** (VPCs, subnets, IAM roles, AWS EKS etc.). This README explains **how those dependencies are referenced**.
@@ -13,7 +13,7 @@ This module:
 
 Typical usage:
 
-- 0-landing-zone → 1-nbs6 → 2-nbs7 → **3-applications \(this module)**
+- 0-landing-zone → 1-nbs7 → **2-applications \(this module)**
 - Environment-specific deployments (dev / stage / prod)
 
 ## 💻 System Prerequisites
@@ -72,7 +72,7 @@ A Kubernetes cluster **must already exist** and is referenced as described below
 ```bash
 # Download appropriate GitHub release from https://github.com/CDCgov/NEDSS-Infrastructure/releases
 unzip <nbs-infrastructure-v<VERSION>.zip # replace version with your downloaded version
-cd terraform/aws/samples/3-applications
+cd terraform/aws/samples/2-applications
 terraform init
 terraform plan
 terraform apply

--- a/terraform/aws/samples/2-applications/linkerd.tf
+++ b/terraform/aws/samples/2-applications/linkerd.tf
@@ -1,5 +1,5 @@
 module "linkerd" {
-  source = "../../modules/3-applications/linkerd"
+  source = "../../modules/2-applications/linkerd"
 
   eks_cluster_endpoint               = local.eks_cluster_endpoint
   cluster_certificate_authority_data = local.cluster_certificate_authority_data

--- a/terraform/aws/samples/2-applications/terraform.tfvars
+++ b/terraform/aws/samples/2-applications/terraform.tfvars
@@ -1,4 +1,4 @@
-# 2-nbs7 parameter inputs
+# 1-nbs7 parameter inputs
 #
 # Search and replace variable values beginning with "EXAMPLE_" to appropriate values
 

--- a/terraform/aws/samples/README.md
+++ b/terraform/aws/samples/README.md
@@ -1,58 +1,60 @@
 # SAMPLES
 
 This directory contains a sample for deploying NBS 7, using a layered
-Terraform approach. Each layer deploys infrastructure or application components 
-referenced in subsequent layers. If you select not to deploy a specific layer, you 
+Terraform approach. Each layer deploys infrastructure or application components
+referenced in subsequent layers. If you select not to deploy a specific layer, you
 must ensure the resources that layer would have provisioned exist and are accessible
 within your environment. These resources are ingested via Terraform `data` calls
 which query your environment. Each layer will by default deploy all modules contained within.
 
 ## Assumptions
-The current deployment of NBS7 assumes there is a functional NBS6 installation. If NBS6 does exist
-you may skip the `1-nbs6` layer.
+
+The current deployment of NBS7 assumes there is a functional NBS6 installation.
 
 ## Directories
+
 For more details see the `README.md` files within these directories.
+
 - [0-landing-zone](./0-landing-zone): Provisions network components.
-- [1-nbs6](./1-nbs6): Provisions NBS6 components (currently just Relation Database Service (RDS)).
-- [2-nbs7](./2-nbs7): Provision NBS7 components.
-- [3-applications](./3-applications): Deploys applications to a Kubernetes cluster.
+- [1-nbs7](./1-nbs7): Provision NBS7 components.
+- [2-applications](./2-applications): Deploys applications to a Kubernetes cluster.
 - [scripts](./scripts): Contains optional scripts to help with layered Terraform implementation.
   <details>
   <summary>list of scripts</summary>
-
-    - [layered_terraform_migration.py](./scripts/layered_terraform_migration.py): split Terraform state from single module into layers.     
+  - [layered_terraform_migration.py](./scripts/layered_terraform_migration.py): split Terraform state from single module into layers.
   </details>
+
 - [archive](./archive): Contains previous deployment samples of NBS7
   <details>
   <summary><strong> directories </strong></summary>
-
-    - `NBS7_standard`: will create a new VPC and integrate with existing system  
-    - `NBS7_existing_network`: assumes the network is created in advance outside of Terraform  
-    - `NBS7_2_subnet`: limited to two pre-existing subnets - not recently tested as of 08/2024  
-    - `NBS6_7`: deploys resources for both NBS 6 (Classic) and NBS 7 (modern) 
-      including a sample database seeded with example data, contact CDC for. 
-      access to appropriate database backup. 
-    - `NBS6_standalone`: deploys resources for both NBS 6 (Classic) 
-      including a sample database seeded with example data, contact CDC for 
-      access to appropriate database backup - most likely you will want to use
-      `NBS6_7` in preference to this sample
+  - `NBS7_standard`: will create a new VPC and integrate with existing system
+  - `NBS7_existing_network`: assumes the network is created in advance outside of Terraform
+  - `NBS7_2_subnet`: limited to two pre-existing subnets - not recently tested as of 08/2024
+  - `NBS6_7`: deploys resources for both NBS 6 (Classic) and NBS 7 (modern)
+    including a sample database seeded with example data, contact CDC for.
+    access to appropriate database backup.
+  - `NBS6_standalone`: deploys resources for both NBS 6 (Classic)
+  including a sample database seeded with example data, contact CDC for
+  access to appropriate database backup - most likely you will want to use
+  `NBS6_7` in preference to this sample
   </details>
 
 ## General Deployment Strategy
-1. Create a copy of the directory layers provided (i.e. `0-landing-zone`, `1-nbs6`, `2-nbs7`, `3-applications`)
+
+1. Create a copy of the directory layers provided (i.e. `0-landing-zone`, `1-nbs7`, `2-applications`)
    - Ideally this copy will be your reference for future deployment and should be treated as you would any **code**
 
 2. Follow the steps for each directory (skipping any undesired layers)
 
-  - Download desired GitHub release from https://github.com/CDCgov/NEDSS-Infrastructure/releases
-  - `unzip <nbs-infrastructure-v<VERSION>.zip` # replace version with your downloaded version
-  - Change directories to desired layer, doing each layer in order per the number that each layer's folder name begins with.
-  - Review the given layer's `README.md` for required (and optional) variable inputs
-  - Make desired changes in `terraform.tfvars` and `terraform.tf` (and optionally `variables.tf`)
-  - Run these commands:
-  ```
-  terraform init
-  terraform plan -out=tfplan # review the resources that will be provisioned
-  terraform apply tfplan
-  ```
+- Download desired GitHub release from https://github.com/CDCgov/NEDSS-Infrastructure/releases
+- `unzip <nbs-infrastructure-v<VERSION>.zip` # replace version with your downloaded version
+- Change directories to desired layer, doing each layer in order per the number that each layer's folder name begins with.
+- Review the given layer's `README.md` for required (and optional) variable inputs
+- Make desired changes in `terraform.tfvars` and `terraform.tf` (and optionally `variables.tf`)
+- Run these commands:
+
+```
+terraform init
+terraform plan -out=tfplan # review the resources that will be provisioned
+terraform apply tfplan
+```

--- a/terraform/aws/samples/scripts/layered_terraform_migration.py
+++ b/terraform/aws/samples/scripts/layered_terraform_migration.py
@@ -196,7 +196,7 @@ def pull_terraform_state(target_dir_path, working_dir):
 def main():
 
     # Set variables (overrides?)
-    layers = ["0-landing-zone", "1-nbs6", "2-nbs7", "3-applications"]
+    layers = ["0-landing-zone", "1-nbs7", "2-applications"]
 
     # 1. Setup Argument Parser
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
Renames 2-nbs7 and 3-applications in the `terraform/aws/samples` directory to align with the current directory structure in `terraform/aws/modules`