### PR TITLE
fix(vnet): update version constraints

### DIFF
--- a/terraform/azure/modules/0-landing-zone/vnet/main.tf
+++ b/terraform/azure/modules/0-landing-zone/vnet/main.tf
@@ -1,6 +1,6 @@
 module "vnet" {
   source  = "Azure/avm-res-network-virtualnetwork/azurerm" # Reference info: https://registry.terraform.io/modules/Azure/avm-res-network-virtualnetwork/azurerm/latest
-  version = ">=0.1.7, <0.2"
+  version = ">=0.21.0, <1.0.0"
   count   = var.enabled ? 1 : 0
 
   name          = var.vnet_name


### PR DESCRIPTION
Fixes an issue where the upper constraint caused a plan or apply to fail.

```
│ There is no available version of module "registry.terraform.io/Azure/avm-res-network-virtualnetwork/azurerm" (.terraform/modules/main.vnet/terraform/azure/modules/0-landing-zone/vnet/main.tf:1) which matches the given version constraint. The newest available version is 0.21.0.
```